### PR TITLE
Require Java-11 in henshin.interpreter and henshin.interpreter.ui

### DIFF
--- a/plugins/org.eclipse.emf.henshin.interpreter.ui/.classpath
+++ b/plugins/org.eclipse.emf.henshin.interpreter.ui/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/plugins/org.eclipse.emf.henshin.interpreter.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.interpreter.ui/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.emf.henshin.interpreter.ui;singleton:=true
 Bundle-Version: 1.9.0.qualifier
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Activator: org.eclipse.emf.henshin.interpreter.ui.HenshinInterpreterUIPlugin$Activator
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.6.0",

--- a/plugins/org.eclipse.emf.henshin.interpreter/.classpath
+++ b/plugins/org.eclipse.emf.henshin.interpreter/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/plugins/org.eclipse.emf.henshin.interpreter/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.interpreter/META-INF/MANIFEST.MF
@@ -3,9 +3,10 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.emf.henshin.interpreter;singleton:=true
+Automatic-Module-Name: org.eclipse.emf.henshin.interpreter
 Bundle-Version: 1.9.0.qualifier
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.emf.ecore.xmi;bundle-version="2.5.0",
  org.eclipse.emf.ecore.change;bundle-version="2.5.0";visibility:=reexport,

--- a/plugins/org.eclipse.emf.henshin.model/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.model/META-INF/MANIFEST.MF
@@ -3,6 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.emf.henshin.model;singleton:=true
+Automatic-Module-Name: org.eclipse.emf.henshin.model
 Bundle-Version: 1.9.0.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11


### PR DESCRIPTION
Both (transitively) require henshin.model, which in turn already requires Java-11, and therefore both (transitively) require Java-11 anyways.

And add missing 'Automatic-Module-Name' header.