### PR TITLE
Add verification build based on Github workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,46 @@
+# This workflow will build the Henshin project with Maven
+
+name: Build Henshin
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    branches:
+      - 'master'
+
+jobs:
+  maven-build:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
+      with:
+        distribution: 'temurin'
+        java-version: |
+          11
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
+      with:
+        maven-version: 3.6.3
+    - name: Cache local Maven repository
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: ~/.m2/repository
+        # re-cache on changes in the pom and target files
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', '**/*.target') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+    - name: Build Henshin
+      run: >-
+           mvn clean verify -DskipTests --fail-at-end
+           --batch-mode --no-transfer-progress --threads 1C

--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,17 @@
 							<version>1.9.0-SNAPSHOT</version>
 						</artifact>
 					</target>
-
 					<environments>
+						<environment>
+							<os>win32</os>
+							<ws>win32</ws>
+							<arch>x86_64</arch>
+						</environment>
+						<environment>
+							<os>linux</os>
+							<ws>gtk</ws>
+							<arch>x86_64</arch>
+						</environment>
 						<environment>
 							<os>macosx</os>
 							<ws>cocoa</ws>


### PR DESCRIPTION
This adds a verification build for this project based on GH-actions/workflow that runs on each push to the `master` branch (others or all can be configured too) and for each Pull-Request against the `master` branch (or when one is updated.

Execution of tests is currently disabled as they are failing at the moment and fixing them requires multiple intermediate steps.

Currently this runs the same build on all three major platforms Windows, MacOS and Linux, but I wonder if that's really necessary since Henshin seem not to have anything platform specific in it, doesn't it?

@dstrueber what's your opinion about that? As part of https://github.com/eclipse-henshin/henshin/issues/5, I also plan to add a Jenkins based build (which can do more than the GH workflow), which will run on Linux.
We could also add all three for now and remove e.g. Linux once the Jenkins build is available. Or just add Linux now and add for example Windows+MacOS when the Jenkins build is available.

Part of
- https://github.com/eclipse-henshin/henshin/issues/5