### PR TITLE
Move all remaining Henshin projects to Java-11

### DIFF
--- a/plugins/adapters/org.eclipse.emf.henshin.adapters.xtext/.classpath
+++ b/plugins/adapters/org.eclipse.emf.henshin.adapters.xtext/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xtend-gen"/>

--- a/plugins/adapters/org.eclipse.emf.henshin.adapters.xtext/META-INF/MANIFEST.MF
+++ b/plugins/adapters/org.eclipse.emf.henshin.adapters.xtext/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Henshinsupport
 Bundle-SymbolicName: org.eclipse.emf.henshin.adapters.xtext;singleton:=true
 Bundle-Version: 1.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Activator: org.eclipse.emf.henshin.adapters.xtext.ui.Activator
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.emf.henshin.adapters.xtext.ui,

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.gc2ac/.classpath
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.gc2ac/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.gc2ac/META-INF/MANIFEST.MF
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.gc2ac/META-INF/MANIFEST.MF
@@ -15,7 +15,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.resources,
  org.eclipse.emf.ecore,
  org.eclipse.emf.henshin.ocl2ac.model;bundle-version="1.0.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.emf.henshin.ocl2ac.gc2ac,
  org.eclipse.emf.henshin.ocl2ac.gc2ac.actions,

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model.edit/.classpath
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model.edit/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model.edit/META-INF/MANIFEST.MF
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model.edit/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-ClassPath: .
 Bundle-Activator: nestedconstraintmodel.provider.NestedconstraintmodelEditPlugin$Implementation
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: graph.provider,
  laxcondition.provider,
  nestedcondition.provider,

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model.editor/.classpath
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model.editor/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model.editor/META-INF/MANIFEST.MF
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model.editor/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-ClassPath: .
 Bundle-Activator: nestedconstraintmodel.presentation.NestedconstraintmodelEditorPlugin$Implementation
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: graph.presentation,
  laxcondition.presentation,
  nestedcondition.presentation,

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model/.classpath
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model/META-INF/MANIFEST.MF
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model/META-INF/MANIFEST.MF
@@ -13,7 +13,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.emf.henshin.ocl2ac.model;visibility:=reexport,
  org.eclipse.core.resources;bundle-version="3.11.1",
  org.eclipse.emf.ecore.editor;bundle-version="2.12.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: compactconditionmodel,
  compactconditionmodel.impl,
  compactconditionmodel.util,

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.ocl2gc/.classpath
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.ocl2gc/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.ocl2gc/META-INF/MANIFEST.MF
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.ocl2gc/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.emf.common;bundle-version="2.11.0",
  org.eclipse.ocl.pivot;bundle-version="1.0.1",
  org.eclipse.emf.henshin.ocl2ac.model;bundle-version="1.0.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.emf.henshin.ocl2ac.ocl2gc,
  org.eclipse.emf.henshin.ocl2ac.ocl2gc.core,

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/.classpath
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/META-INF/MANIFEST.MF
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/META-INF/MANIFEST.MF
@@ -17,7 +17,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.emf.henshin.ocl2ac.gc2ac;bundle-version="1.0.0",
  org.eclipse.emf.henshin.ocl2ac.model;bundle-version="1.0.0",
  org.eclipse.emf.common.ui;bundle-version="2.11.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.emf.henshin.ocl2ac.tool,
  org.eclipse.emf.henshin.ocl2ac.tool.commands,

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.utils/.classpath
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.utils/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<accessrules>
 			<accessrule kind="accessible" pattern="&apos;de/unimarburg/swt/ocl2ac/**&apos;"/>
 		</accessrules>

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.utils/META-INF/MANIFEST.MF
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.utils/META-INF/MANIFEST.MF
@@ -16,7 +16,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.emf.edit.ui;bundle-version="2.12.0",
  org.eclipse.ui.ide;bundle-version="3.12.3",
  org.apache.commons.io;bundle-version="2.2.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.emf.henshin.ocl2ac.utils.henshin.simplification,
  org.eclipse.emf.henshin.ocl2ac.utils.printer,

--- a/plugins/org.eclipse.emf.henshin.diagram/.classpath
+++ b/plugins/org.eclipse.emf.henshin.diagram/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/org.eclipse.emf.henshin.diagram/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.diagram/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.emf.henshin.diagram; singleton:=true
 Bundle-Version: 1.9.0.qualifier
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.emf.henshin.diagram.part.HenshinDiagramEditorPlugin

--- a/plugins/org.eclipse.emf.henshin.edit/.classpath
+++ b/plugins/org.eclipse.emf.henshin.edit/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/org.eclipse.emf.henshin.edit/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.edit/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.emf.henshin.edit;singleton:=true
 Bundle-Version: 1.9.0.qualifier
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.emf.henshin.provider.HenshinEditPlugin$Implementation

--- a/plugins/org.eclipse.emf.henshin.editor/.classpath
+++ b/plugins/org.eclipse.emf.henshin.editor/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/org.eclipse.emf.henshin.editor/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.editor/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.emf.henshin.editor;singleton:=true
 Bundle-Version: 1.9.0.qualifier
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.emf.henshin.presentation.HenshinEditorPlugin$Implementation

--- a/plugins/org.eclipse.emf.henshin.examples/.classpath
+++ b/plugins/org.eclipse.emf.henshin.examples/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/org.eclipse.emf.henshin.examples/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.examples/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.emf.henshin.examples;singleton:=true
 Bundle-Version: 1.9.0.qualifier
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.6.0",

--- a/plugins/org.eclipse.emf.henshin.giraph/.classpath
+++ b/plugins/org.eclipse.emf.henshin.giraph/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/plugins/org.eclipse.emf.henshin.giraph/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.giraph/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.emf.henshin.giraph;singleton:=true
 Bundle-Version: 1.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.emf.henshin.giraph,
  org.eclipse.emf.henshin.giraph.templates
 Require-Bundle: org.eclipse.ant.core;bundle-version="3.2.0",

--- a/plugins/org.eclipse.emf.henshin.monitoring.kieker/.classpath
+++ b/plugins/org.eclipse.emf.henshin.monitoring.kieker/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry exported="true" kind="lib" path="kieker-1.13.jar"/>
 	<classpathentry kind="output" path="bin"/>

--- a/plugins/org.eclipse.emf.henshin.monitoring.kieker/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.monitoring.kieker/META-INF/MANIFEST.MF
@@ -193,7 +193,7 @@ Export-Package: com.beust.jcommander,
  org.jctools.queues.atomic,
  org.jctools.queues.spec,
  org.jctools.util
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.emf.ecore,
  org.eclipse.core.resources,
  org.eclipse.ui;bundle-version="3.108.1",

--- a/plugins/org.eclipse.emf.henshin.monitoring.ui/.classpath
+++ b/plugins/org.eclipse.emf.henshin.monitoring.ui/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/plugins/org.eclipse.emf.henshin.monitoring.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.monitoring.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.emf.henshin.monitoring.ui
 Bundle-Version: 1.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.swt;bundle-version="3.105.3"
 Export-Package: org.eclipse.emf.henshin.monitoring.ui,
  org.eclipse.emf.henshin.monitoring.ui.util

--- a/plugins/org.eclipse.emf.henshin.multicda.cda/.classpath
+++ b/plugins/org.eclipse.emf.henshin.multicda.cda/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/plugins/org.eclipse.emf.henshin.multicda.cda/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.multicda.cda/META-INF/MANIFEST.MF
@@ -14,7 +14,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.junit;bundle-version="4.0.0",
  org.eclipse.emf.ecore,
  org.eclipse.emf.common
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.emf.henshin.multicda.cda,
  org.eclipse.emf.henshin.multicda.cda.computation,

--- a/plugins/org.eclipse.emf.henshin.multicda.cpa.ui/.classpath
+++ b/plugins/org.eclipse.emf.henshin.multicda.cpa.ui/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/plugins/org.eclipse.emf.henshin.multicda.cpa.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.multicda.cpa.ui/META-INF/MANIFEST.MF
@@ -19,7 +19,7 @@ Require-Bundle: org.eclipse.ui.ide;bundle-version="3.6.0",
  org.eclipse.e4.ui.model.workbench;bundle-version="1.1.0",
  org.eclipse.e4.core.contexts;bundle-version="1.3.100",
  org.eclipse.emf.henshin.multicda.cda
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName
 Bundle-Name: %pluginName

--- a/plugins/org.eclipse.emf.henshin.multicda.cpa/.classpath
+++ b/plugins/org.eclipse.emf.henshin.multicda.cpa/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/plugins/org.eclipse.emf.henshin.multicda.cpa/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.multicda.cpa/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-SymbolicName: org.eclipse.emf.henshin.multicda.cpa;singleton:=true
 Bundle-Version: 1.9.0.qualifier
 Bundle-ClassPath: .
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.emf.henshin.multicda.cpa.CriticalPairAnalysisPlugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="2.6.0",

--- a/plugins/org.eclipse.emf.henshin.rulegen.tests/.classpath
+++ b/plugins/org.eclipse.emf.henshin.rulegen.tests/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/plugins/org.eclipse.emf.henshin.rulegen.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.rulegen.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.emf.henshin.rulegen.tests;singleton:=true
 Bundle-Version: 1.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: %providerName
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.junit;bundle-version="4.12.0",

--- a/plugins/org.eclipse.emf.henshin.rulegen.ui/.classpath
+++ b/plugins/org.eclipse.emf.henshin.rulegen.ui/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/plugins/org.eclipse.emf.henshin.rulegen.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.rulegen.ui/META-INF/MANIFEST.MF
@@ -10,6 +10,6 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.emf.ecore,
  org.eclipse.emf.henshin.model,
  org.eclipse.emf.henshin.rulegen
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/plugins/org.eclipse.emf.henshin.rulegen/.classpath
+++ b/plugins/org.eclipse.emf.henshin.rulegen/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/plugins/org.eclipse.emf.henshin.rulegen/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.rulegen/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.ecore,
  org.eclipse.emf.compare;bundle-version="3.1.2",
  org.eclipse.emf.henshin.model
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.emf.henshin.rulegen
 Bundle-Vendor: %providerName
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.eclipse.emf.henshin.statespace.explorer/.classpath
+++ b/plugins/org.eclipse.emf.henshin.statespace.explorer/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/plugins/org.eclipse.emf.henshin.statespace.explorer/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.statespace.explorer/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.emf.henshin.statespace.explorer;singleton:=true
 Bundle-Version: 1.9.0.qualifier
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.emf.henshin.statespace.explorer.StateSpaceExplorerPlugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.6.0",

--- a/plugins/org.eclipse.emf.henshin.statespace.external/.classpath
+++ b/plugins/org.eclipse.emf.henshin.statespace.external/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/plugins/org.eclipse.emf.henshin.statespace.external/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.statespace.external/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: External State Space Validators
 Bundle-SymbolicName: org.eclipse.emf.henshin.statespace.external;singleton:=true
 Bundle-Version: 1.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: Eclipse Modeling Project
 Require-Bundle: org.eclipse.core.resources;bundle-version="3.6.0",
  org.eclipse.core.runtime;bundle-version="3.6.0",

--- a/plugins/org.eclipse.emf.henshin.statespace/.classpath
+++ b/plugins/org.eclipse.emf.henshin.statespace/.classpath
@@ -2,6 +2,6 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/org.eclipse.emf.henshin.statespace/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.statespace/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.emf.henshin.statespace;singleton:=true
 Bundle-Version: 1.9.0.qualifier
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Require-Bundle: org.eclipse.core.resources;bundle-version="3.6.0",

--- a/plugins/org.eclipse.emf.henshin.tests/.classpath
+++ b/plugins/org.eclipse.emf.henshin.tests/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/org.eclipse.emf.henshin.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.tests/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Version: 1.9.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.emf.henshin.tests.EGraphTestmodel,
  org.eclipse.emf.henshin.tests.basic,
  org.eclipse.emf.henshin.tests.framework,

--- a/plugins/org.eclipse.emf.henshin.text.ide/.classpath
+++ b/plugins/org.eclipse.emf.henshin.text.ide/.classpath
@@ -3,7 +3,7 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="src-gen"/>
 	<classpathentry kind="src" path="xtend-gen"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/org.eclipse.emf.henshin.text.ide/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.text.ide/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.emf.henshin.text,
  org.eclipse.xtext.ide,
  org.eclipse.xtext.xbase.ide
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.emf.henshin.text.ide.contentassist.antlr,
  org.eclipse.emf.henshin.text.ide.contentassist.antlr.internal
 

--- a/plugins/org.eclipse.emf.henshin.text.tests/.classpath
+++ b/plugins/org.eclipse.emf.henshin.text.tests/.classpath
@@ -3,7 +3,7 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="src-gen"/>
 	<classpathentry kind="src" path="xtend-gen"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/org.eclipse.emf.henshin.text.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.text.tests/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Require-Bundle: org.eclipse.emf.henshin.text,
  org.eclipse.xtext.junit4,
  org.eclipse.xtext.xbase.junit,
  org.eclipse.xtext.xbase.lib
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.emf.henshin.text.tests
 Import-Package: org.hamcrest.core,
  org.junit;version="4.5.0",

--- a/plugins/org.eclipse.emf.henshin.text.transformation.tests/.classpath
+++ b/plugins/org.eclipse.emf.henshin.text.transformation.tests/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xtend-gen"/>

--- a/plugins/org.eclipse.emf.henshin.text.transformation.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.text.transformation.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.emf.henshin.text.transformation.tests
 Bundle-SymbolicName: org.eclipse.emf.henshin.text.transformation.tests
 Bundle-Version: 1.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit;bundle-version="4.12.0",
  org.eclipse.emf.ecore,
  org.eclipse.emf.compare,

--- a/plugins/org.eclipse.emf.henshin.text.ui/.classpath
+++ b/plugins/org.eclipse.emf.henshin.text.ui/.classpath
@@ -3,7 +3,7 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="src-gen"/>
 	<classpathentry kind="src" path="xtend-gen"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/org.eclipse.emf.henshin.text.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.text.ui/META-INF/MANIFEST.MF
@@ -23,7 +23,7 @@ Require-Bundle: org.eclipse.emf.henshin.text,
  org.eclipse.emf.henshin.editor;bundle-version="1.3.0",
  org.eclipse.emf.henshin.interpreter.ui;bundle-version="1.3.0"
 Import-Package: org.apache.log4j
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.emf.henshin.text.ui.contentassist,
  org.eclipse.emf.henshin.text.ui.internal,
  org.eclipse.emf.henshin.text.ui.quickfix,

--- a/plugins/org.eclipse.emf.henshin.text/.classpath
+++ b/plugins/org.eclipse.emf.henshin.text/.classpath
@@ -3,7 +3,7 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="src-gen"/>
 	<classpathentry kind="src" path="xtend-gen"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/org.eclipse.emf.henshin.text/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.text/META-INF/MANIFEST.MF
@@ -17,7 +17,7 @@ Require-Bundle: org.eclipse.xtext;bundle-version="2.10.0",
  org.eclipse.core.resources,
  org.eclipse.jdt.core,
  javax.annotation
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.emf.henshin.text.henshin_text.impl,
  org.eclipse.emf.henshin.text.validation,
  org.eclipse.emf.henshin.text.henshin_text,

--- a/plugins/org.eclipse.emf.henshin.trace/.classpath
+++ b/plugins/org.eclipse.emf.henshin.trace/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/org.eclipse.emf.henshin.trace/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.trace/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 1.9.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.emf.henshin.trace,
  org.eclipse.emf.henshin.trace.impl,
  org.eclipse.emf.henshin.trace.util

--- a/plugins/org.eclipse.emf.henshin.wrap/.classpath
+++ b/plugins/org.eclipse.emf.henshin.wrap/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/org.eclipse.emf.henshin.wrap/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.wrap/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 1.9.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.emf.henshin.wrap,
  org.eclipse.emf.henshin.wrap.impl,
  org.eclipse.emf.henshin.wrap.util

--- a/plugins/variability/org.eclipse.emf.henshin.variability.configuration.ui/.classpath
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.configuration.ui/.classpath
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry exported="true" kind="lib" path="lib/swing2swt.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/variability/org.eclipse.emf.henshin.variability.configuration.ui/META-INF/MANIFEST.MF
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.configuration.ui/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Require-Bundle: org.eclipse.emf.henshin.diagram,
  org.eclipse.emf.databinding,
  org.eclipse.gmf.runtime.diagram.ui;bundle-version="1.8.0",
  org.eclipse.core.databinding.property
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .,
  lib/swing2swt.jar

--- a/plugins/variability/org.eclipse.emf.henshin.variability.configuration/.classpath
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.configuration/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/variability/org.eclipse.emf.henshin.variability.configuration/META-INF/MANIFEST.MF
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.configuration/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Version: 1.9.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: configuration,
  configuration.impl,
  configuration.util

--- a/plugins/variability/org.eclipse.emf.henshin.variability.mergein.refactoring/.classpath
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.mergein.refactoring/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/plugins/variability/org.eclipse.emf.henshin.variability.mergein.refactoring/META-INF/MANIFEST.MF
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.mergein.refactoring/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.emf.henshin.variability.mergein;bundle-version="1.0.0",
  org.eclipse.core.resources;bundle-version="3.9.1",
  org.eclipse.emf.henshin.variability
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.emf.henshin.variability.mergein.refactoring.logic,
  org.eclipse.emf.henshin.variability.mergein.refactoring.popup.actions,

--- a/plugins/variability/org.eclipse.emf.henshin.variability.mergein.ui/.classpath
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.mergein.ui/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="org.eclipse.emf.henshin.variability.bin"/>

--- a/plugins/variability/org.eclipse.emf.henshin.variability.mergein.ui/META-INF/MANIFEST.MF
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.mergein.ui/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Require-Bundle: org.eclipse.gmf.runtime.emf.ui.properties,
  org.eclipse.emf.henshin.diagram,
  org.eclipse.emf.henshin.variability.mergein.refactoring,
  org.eclipse.emf.henshin.variability.mergein
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.emf.henshin.variability.mergein.ui
 Bundle-ClassPath: .

--- a/plugins/variability/org.eclipse.emf.henshin.variability.mergein/.classpath
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.mergein/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/plugins/variability/org.eclipse.emf.henshin.variability.mergein/META-INF/MANIFEST.MF
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.mergein/META-INF/MANIFEST.MF
@@ -16,7 +16,7 @@ Bundle-ClassPath: .,
  lib/parsemis-2008-12-01.jar
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: mergeSuggestion,
  mergeSuggestion.impl,
  mergeSuggestion.util,

--- a/plugins/variability/org.eclipse.emf.henshin.variability.test/.classpath
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.test/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="tests">
 		<attributes>

--- a/plugins/variability/org.eclipse.emf.henshin.variability.test/META-INF/MANIFEST.MF
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.test/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Require-Bundle: org.eclipse.emf.henshin.variability.mergein,
  org.eclipse.emf.henshin.variability,
  org.junit
 Export-Package: org.eclipse.emf.henshin.variability.tests
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: org.eclipse.emf.henshin.variability.test
 Bundle-ClassPath: .,
  lib/gson-2.8.6.jar

--- a/plugins/variability/org.eclipse.emf.henshin.variability/.classpath
+++ b/plugins/variability/org.eclipse.emf.henshin.variability/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry exported="true" kind="lib" path="lib/aima-core-3.0.0.jar"/>

--- a/plugins/variability/org.eclipse.emf.henshin.variability/META-INF/MANIFEST.MF
+++ b/plugins/variability/org.eclipse.emf.henshin.variability/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 1.9.0.qualifier
 Bundle-ClassPath: .,
  lib/aima-core-3.0.0.jar
 Bundle-Vendor: %providerName
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: aima.core.logic.propositional.kb.data,
  aima.core.logic.propositional.parsing.ast,
  org.eclipse.emf.henshin.variability,

--- a/pom.xml
+++ b/pom.xml
@@ -60,9 +60,7 @@
 		<tycho-version>1.3.0</tycho-version>
 		<tycho-extras-version>1.3.0</tycho-extras-version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.target>11</maven.compiler.target>
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.release />
+		<maven.compiler.release>11</maven.compiler.release>
 	</properties>
 
 	<build>


### PR DESCRIPTION
And just set the Java Compiler's more advanced 'release' option instead of just 'source' and 'target'.

After `o.e.henshin.model` and `o.e.henshin.interpreter` requires Java-11 already (see also https://github.com/eclipse-henshin/henshin/pull/3), all other henshin projects transitively require Java-11 anyways.
And moving all projects make subsequent updates of the build easier.

@dstrueber could you please review this?