### PR TITLE
Add missing Automatic-Module-Name Manifest header

### DIFF
--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.gc2ac/META-INF/MANIFEST.MF
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.gc2ac/META-INF/MANIFEST.MF
@@ -21,3 +21,4 @@ Export-Package: org.eclipse.emf.henshin.ocl2ac.gc2ac,
  org.eclipse.emf.henshin.ocl2ac.gc2ac.actions,
  org.eclipse.emf.henshin.ocl2ac.gc2ac.core,
  org.eclipse.emf.henshin.ocl2ac.gc2ac.util
+Automatic-Module-Name: org.eclipse.emf.henshin.ocl2ac.gc2ac

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model.edit/META-INF/MANIFEST.MF
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model.edit/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.emf.henshin.ocl2ac.model.edit;singleton:=true
 Bundle-Version: 1.9.0.qualifier
-Bundle-ClassPath: .
 Bundle-Activator: nestedconstraintmodel.provider.NestedconstraintmodelEditPlugin$Implementation
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
@@ -16,3 +15,4 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.henshin.ocl2ac.model;visibility:=reexport,
  org.eclipse.emf.edit;visibility:=reexport
 Bundle-ActivationPolicy: lazy
+Automatic-Module-Name: org.eclipse.emf.henshin.ocl2ac.model.edit

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model.editor/META-INF/MANIFEST.MF
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model.editor/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.emf.henshin.ocl2ac.model.editor;singleton:=true
 Bundle-Version: 1.9.0.qualifier
-Bundle-ClassPath: .
 Bundle-Activator: nestedconstraintmodel.presentation.NestedconstraintmodelEditorPlugin$Implementation
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
@@ -19,3 +18,4 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.edit.ui;visibility:=reexport,
  org.eclipse.ui.ide;visibility:=reexport
 Bundle-ActivationPolicy: lazy
+Automatic-Module-Name: org.eclipse.emf.henshin.ocl2ac.model.editor

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model/META-INF/MANIFEST.MF
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.emf.henshin.ocl2ac.model;singleton:=true
 Bundle-Version: 1.9.0.qualifier
-Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-Activator: org.eclipse.emf.henshin.ocl2ac.model.Activator
@@ -36,3 +35,4 @@ Export-Package: compactconditionmodel,
  nestedconstraintmodel.impl,
  nestedconstraintmodel.util
 Bundle-ActivationPolicy: lazy
+Automatic-Module-Name: org.eclipse.emf.henshin.ocl2ac.model

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.ocl2gc/META-INF/MANIFEST.MF
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.ocl2gc/META-INF/MANIFEST.MF
@@ -15,3 +15,4 @@ Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.emf.henshin.ocl2ac.ocl2gc,
  org.eclipse.emf.henshin.ocl2ac.ocl2gc.core,
  org.eclipse.emf.henshin.ocl2ac.ocl2gc.util
+Automatic-Module-Name: org.eclipse.emf.henshin.ocl2ac.ocl2gc

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/META-INF/MANIFEST.MF
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/META-INF/MANIFEST.MF
@@ -22,3 +22,4 @@ Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.emf.henshin.ocl2ac.tool,
  org.eclipse.emf.henshin.ocl2ac.tool.commands,
  org.eclipse.emf.henshin.ocl2ac.tool.optimizer
+Automatic-Module-Name: org.eclipse.emf.henshin.ocl2ac.tool

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.utils/META-INF/MANIFEST.MF
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.utils/META-INF/MANIFEST.MF
@@ -21,3 +21,4 @@ Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.emf.henshin.ocl2ac.utils.henshin.simplification,
  org.eclipse.emf.henshin.ocl2ac.utils.printer,
  org.eclipse.emf.henshin.ocl2ac.utils.viewer
+Automatic-Module-Name: org.eclipse.emf.henshin.ocl2ac.utils

--- a/plugins/org.eclipse.emf.henshin.diagram/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.diagram/META-INF/MANIFEST.MF
@@ -7,7 +7,6 @@ Bundle-Version: 1.9.0.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
-Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.emf.henshin.diagram.part.HenshinDiagramEditorPlugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.6.0",
  org.eclipse.core.resources;bundle-version="3.6.0",
@@ -44,4 +43,4 @@ Export-Package: org.eclipse.emf.henshin.diagram.edit.commands,
  org.eclipse.emf.henshin.diagram.edit.policies,
  org.eclipse.emf.henshin.diagram.part,
  org.eclipse.emf.henshin.diagram.providers
-Eclipse-LazyStart: true
+Automatic-Module-Name: org.eclipse.emf.henshin.diagram

--- a/plugins/org.eclipse.emf.henshin.edit/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.edit/META-INF/MANIFEST.MF
@@ -7,7 +7,6 @@ Bundle-Version: 1.9.0.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
-Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.emf.henshin.provider.HenshinEditPlugin$Implementation
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.6.0",
  org.eclipse.emf.edit;bundle-version="2.6.0";visibility:=reexport,
@@ -17,4 +16,4 @@ Export-Package: org.eclipse.emf.henshin.commands,
  org.eclipse.emf.henshin.provider.filter,
  org.eclipse.emf.henshin.provider.trans,
  org.eclipse.emf.henshin.provider.util
-
+Automatic-Module-Name: org.eclipse.emf.henshin.edit

--- a/plugins/org.eclipse.emf.henshin.editor/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.editor/META-INF/MANIFEST.MF
@@ -7,7 +7,6 @@ Bundle-Version: 1.9.0.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
-Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.emf.henshin.presentation.HenshinEditorPlugin$Implementation
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.6.0",
  org.eclipse.core.resources;bundle-version="3.6.0";visibility:=reexport,
@@ -25,3 +24,4 @@ Export-Package: org.eclipse.emf.henshin.editor,
  org.eclipse.emf.henshin.editor.filter,
  org.eclipse.emf.henshin.editor.menuContributors,
  org.eclipse.emf.henshin.presentation
+Automatic-Module-Name: org.eclipse.emf.henshin.editor

--- a/plugins/org.eclipse.emf.henshin.examples/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.examples/META-INF/MANIFEST.MF
@@ -7,7 +7,6 @@ Bundle-Version: 1.9.0.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
-Bundle-ClassPath: .
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.6.0",
  org.eclipse.emf.codegen.ecore;bundle-version="2.6.0",
  org.eclipse.emf.henshin.trace;bundle-version="0.9.0",
@@ -37,3 +36,4 @@ Export-Package: org.eclipse.emf.henshin.examples.aggregation,
  org.eclipse.emf.henshin.examples.universitycourses,
  org.eclipse.emf.henshin.examples.wrap.copy,
  org.eclipse.emf.henshin.examples.wrap.mme
+Automatic-Module-Name: org.eclipse.emf.henshin.examples

--- a/plugins/org.eclipse.emf.henshin.giraph/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.giraph/META-INF/MANIFEST.MF
@@ -17,3 +17,4 @@ Require-Bundle: org.eclipse.ant.core;bundle-version="3.2.0",
  org.eclipse.debug.ui
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName
+Automatic-Module-Name: org.eclipse.emf.henshin.giraph

--- a/plugins/org.eclipse.emf.henshin.interpreter.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.interpreter.ui/META-INF/MANIFEST.MF
@@ -26,3 +26,4 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.6.0",
  org.eclipse.debug.ui
 Export-Package: org.eclipse.emf.henshin.interpreter.ui.extension,
  org.eclipse.emf.henshin.interpreter.ui.wizard
+Automatic-Module-Name: org.eclipse.emf.henshin.interpreter.ui

--- a/plugins/org.eclipse.emf.henshin.interpreter/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.interpreter/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.emf.henshin.interpreter;singleton:=true
-Automatic-Module-Name: org.eclipse.emf.henshin.interpreter
 Bundle-Version: 1.9.0.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
@@ -23,3 +22,4 @@ Export-Package: org.eclipse.emf.henshin.interpreter,
  org.eclipse.emf.henshin.interpreter.matching.constraints,
  org.eclipse.emf.henshin.interpreter.monitoring,
  org.eclipse.emf.henshin.interpreter.util
+Automatic-Module-Name: org.eclipse.emf.henshin.interpreter

--- a/plugins/org.eclipse.emf.henshin.model/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.model/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.emf.henshin.model;singleton:=true
-Automatic-Module-Name: org.eclipse.emf.henshin.model
 Bundle-Version: 1.9.0.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
@@ -28,3 +27,4 @@ Export-Package: org.eclipse.emf.henshin,
  org.eclipse.emf.henshin.model.staticanalysis,
  org.eclipse.emf.henshin.model.util
 Bundle-Activator: org.eclipse.emf.henshin.HenshinModelPlugin$Implementation
+Automatic-Module-Name: org.eclipse.emf.henshin.model

--- a/plugins/org.eclipse.emf.henshin.monitoring.kieker/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.monitoring.kieker/META-INF/MANIFEST.MF
@@ -202,3 +202,4 @@ Require-Bundle: org.eclipse.emf.ecore,
  org.eclipse.equinox.registry,
  org.eclipse.emf.henshin.interpreter,
  org.eclipse.emf.henshin.interpreter.ui
+Automatic-Module-Name: org.eclipse.emf.henshin.monitoring.kieker

--- a/plugins/org.eclipse.emf.henshin.monitoring.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.monitoring.ui/META-INF/MANIFEST.MF
@@ -8,3 +8,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.swt;bundle-version="3.105.3"
 Export-Package: org.eclipse.emf.henshin.monitoring.ui,
  org.eclipse.emf.henshin.monitoring.ui.util
+Automatic-Module-Name: org.eclipse.emf.henshin.monitoring.ui

--- a/plugins/org.eclipse.emf.henshin.multicda.cda/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.multicda.cda/META-INF/MANIFEST.MF
@@ -24,3 +24,4 @@ Export-Package: org.eclipse.emf.henshin.multicda.cda,
  org.eclipse.emf.henshin.multicda.cda.tasks,
  org.eclipse.emf.henshin.multicda.cda.units,
  org.eclipse.emf.henshin.preprocessing
+Automatic-Module-Name: org.eclipse.emf.henshin.multicda.cda

--- a/plugins/org.eclipse.emf.henshin.multicda.cpa.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.multicda.cpa.ui/META-INF/MANIFEST.MF
@@ -34,3 +34,4 @@ Import-Package: org.eclipse.emf.ecore.presentation,
  org.eclipse.emf.henshin.presentation,
  org.eclipse.gmf.runtime.notation,
  org.eclipse.ui.views.contentoutline
+Automatic-Module-Name: org.eclipse.emf.henshin.multicda.cpa.ui

--- a/plugins/org.eclipse.emf.henshin.multicda.cpa/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.multicda.cpa/META-INF/MANIFEST.MF
@@ -4,7 +4,6 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.emf.henshin.multicda.cpa;singleton:=true
 Bundle-Version: 1.9.0.qualifier
-Bundle-ClassPath: .
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
@@ -28,3 +27,4 @@ Export-Package: org.eclipse.emf.henshin.multicda.cpa,
  org.eclipse.emf.henshin.multicda.cpa.modelExtension,
  org.eclipse.emf.henshin.multicda.cpa.persist,
  org.eclipse.emf.henshin.multicda.cpa.result
+Automatic-Module-Name: org.eclipse.emf.henshin.multicda.cpa

--- a/plugins/org.eclipse.emf.henshin.rulegen.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.rulegen.tests/META-INF/MANIFEST.MF
@@ -10,3 +10,4 @@ Require-Bundle: org.junit;bundle-version="4.12.0",
  org.eclipse.emf.henshin.tests,
  org.eclipse.emf.henshin.rulegen,
  org.eclipse.emf.compare
+Automatic-Module-Name: org.eclipse.emf.henshin.rulegen.tests

--- a/plugins/org.eclipse.emf.henshin.rulegen.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.rulegen.ui/META-INF/MANIFEST.MF
@@ -13,3 +13,4 @@ Require-Bundle: org.eclipse.ui,
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName
+Automatic-Module-Name: org.eclipse.emf.henshin.rulegen.ui

--- a/plugins/org.eclipse.emf.henshin.rulegen/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.rulegen/META-INF/MANIFEST.MF
@@ -13,3 +13,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.emf.henshin.rulegen
 Bundle-Vendor: %providerName
 Bundle-ActivationPolicy: lazy
+Automatic-Module-Name: org.eclipse.emf.henshin.rulegen

--- a/plugins/org.eclipse.emf.henshin.statespace.explorer/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.statespace.explorer/META-INF/MANIFEST.MF
@@ -17,3 +17,4 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.6.0",
  org.eclipse.emf.henshin.model;bundle-version="0.9.0",
  org.eclipse.emf.henshin.editor;bundle-version="0.9.0",
  org.eclipse.emf.henshin.statespace;bundle-version="0.9.0"
+Automatic-Module-Name: org.eclipse.emf.henshin.statespace.explorer

--- a/plugins/org.eclipse.emf.henshin.statespace.external/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.statespace.external/META-INF/MANIFEST.MF
@@ -14,3 +14,4 @@ Export-Package: org.eclipse.emf.henshin.statespace.external,
  org.eclipse.emf.henshin.statespace.external.mcrl2,
  org.eclipse.emf.henshin.statespace.external.prism,
  org.eclipse.emf.henshin.statespace.external.tikz
+Automatic-Module-Name: org.eclipse.emf.henshin.statespace.external

--- a/plugins/org.eclipse.emf.henshin.statespace/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.statespace/META-INF/MANIFEST.MF
@@ -7,7 +7,6 @@ Bundle-Version: 1.9.0.qualifier
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
-Bundle-ClassPath: .
 Require-Bundle: org.eclipse.core.resources;bundle-version="3.6.0",
  org.eclipse.core.runtime;bundle-version="3.6.0",
  org.eclipse.emf.ecore;bundle-version="2.6.0";visibility:=reexport,
@@ -24,3 +23,4 @@ Export-Package: org.eclipse.emf.henshin.statespace,
  org.eclipse.emf.henshin.statespace.resource,
  org.eclipse.emf.henshin.statespace.util
 Bundle-Activator: org.eclipse.emf.henshin.statespace.StateSpacePlugin$Implementation
+Automatic-Module-Name: org.eclipse.emf.henshin.statespace

--- a/plugins/org.eclipse.emf.henshin.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.tests/META-INF/MANIFEST.MF
@@ -2,9 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.emf.henshin.tests;singleton:=true
-Automatic-Module-Name: org.eclipse.emf.henshin.tests
 Bundle-Version: 1.9.0.qualifier
-Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
@@ -28,3 +26,4 @@ Require-Bundle: org.eclipse.core.resources;bundle-version="3.6.0",
  org.eclipse.debug.core;bundle-version="3.10.100"
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.debug.core
+Automatic-Module-Name: org.eclipse.emf.henshin.tests

--- a/plugins/org.eclipse.emf.henshin.text.ide/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.text.ide/META-INF/MANIFEST.MF
@@ -11,4 +11,4 @@ Require-Bundle: org.eclipse.emf.henshin.text,
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.emf.henshin.text.ide.contentassist.antlr,
  org.eclipse.emf.henshin.text.ide.contentassist.antlr.internal
-
+Automatic-Module-Name: org.eclipse.emf.henshin.text.ide

--- a/plugins/org.eclipse.emf.henshin.text.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.text.tests/META-INF/MANIFEST.MF
@@ -19,3 +19,4 @@ Import-Package: org.hamcrest.core,
  org.junit.runners;version="4.5.0",
  org.junit.runner.manipulation;version="4.5.0",
  org.junit.runner.notification;version="4.5.0"
+Automatic-Module-Name: org.eclipse.emf.henshin.text.tests

--- a/plugins/org.eclipse.emf.henshin.text.transformation.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.text.transformation.tests/META-INF/MANIFEST.MF
@@ -25,4 +25,4 @@ Import-Package: com.google.inject,
  org.eclipse.emf.henshin.text,
  org.eclipse.emf.henshin.text.ui.util
 Bundle-Vendor: Eclipse Modeling Project
-
+Automatic-Module-Name: org.eclipse.emf.henshin.text.transformation.tests

--- a/plugins/org.eclipse.emf.henshin.text.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.text.ui/META-INF/MANIFEST.MF
@@ -30,3 +30,4 @@ Export-Package: org.eclipse.emf.henshin.text.ui.contentassist,
  org.eclipse.emf.henshin.text.ui.util,
  org.eclipse.emf.henshin.text.ui.labeling
 Bundle-Activator: org.eclipse.emf.henshin.text.ui.internal.TextActivator
+Automatic-Module-Name: org.eclipse.emf.henshin.text.ui

--- a/plugins/org.eclipse.emf.henshin.text/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.text/META-INF/MANIFEST.MF
@@ -31,3 +31,4 @@ Export-Package: org.eclipse.emf.henshin.text.henshin_text.impl,
  org.eclipse.emf.henshin.text.generator,
  org.eclipse.emf.henshin.text.formatting2
 Import-Package: org.apache.log4j
+Automatic-Module-Name: org.eclipse.emf.henshin.text

--- a/plugins/org.eclipse.emf.henshin.trace/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.trace/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.emf.henshin.trace;singleton:=true
 Bundle-Version: 1.9.0.qualifier
-Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
@@ -13,3 +12,4 @@ Export-Package: org.eclipse.emf.henshin.trace,
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.6.0",
  org.eclipse.emf.ecore;bundle-version="2.6.0";visibility:=reexport
 Bundle-ActivationPolicy: lazy
+Automatic-Module-Name: org.eclipse.emf.henshin.trace

--- a/plugins/org.eclipse.emf.henshin.wrap/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.wrap/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.emf.henshin.wrap;singleton:=true
 Bundle-Version: 1.9.0.qualifier
-Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
@@ -13,3 +12,4 @@ Export-Package: org.eclipse.emf.henshin.wrap,
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.ecore;visibility:=reexport
 Bundle-ActivationPolicy: lazy
+Automatic-Module-Name: org.eclipse.emf.henshin.wrap

--- a/plugins/variability/org.eclipse.emf.henshin.variability.configuration/META-INF/MANIFEST.MF
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.configuration/META-INF/MANIFEST.MF
@@ -2,9 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.emf.henshin.variability.configuration;singleton:=true
-Automatic-Module-Name: org.eclipse.emf.henshin.variability.configuration
 Bundle-Version: 1.9.0.qualifier
-Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
@@ -15,3 +13,4 @@ Require-Bundle: org.eclipse.emf.henshin.model;visibility:=reexport,
  org.eclipse.emf.henshin.variability,
  org.eclipse.emf.transaction
 Bundle-ActivationPolicy: lazy
+Automatic-Module-Name: org.eclipse.emf.henshin.variability.configuration

--- a/plugins/variability/org.eclipse.emf.henshin.variability.mergein.refactoring/META-INF/MANIFEST.MF
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.mergein.refactoring/META-INF/MANIFEST.MF
@@ -15,4 +15,3 @@ Export-Package: org.eclipse.emf.henshin.variability.mergein.refactoring.logic,
  org.eclipse.emf.henshin.variability.mergein.refactoring.popup.actions,
  org.eclipse.emf.henshin.variability.mergein.refactoring.util
 Automatic-Module-Name: org.eclipse.emf.henshin.variability.mergein.refactoring
-Bundle-ClassPath: .

--- a/plugins/variability/org.eclipse.emf.henshin.variability.mergein.ui/META-INF/MANIFEST.MF
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.mergein.ui/META-INF/MANIFEST.MF
@@ -12,4 +12,3 @@ Require-Bundle: org.eclipse.gmf.runtime.emf.ui.properties,
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: org.eclipse.emf.henshin.variability.mergein.ui
-Bundle-ClassPath: .


### PR DESCRIPTION
and remove unnecessary 'Bundle-ClassPath: .' entries as the dot is the default for the 'Bundle-ClassPath' header.

The `Automatic-Module-Name` is recommended for usage in Java-9 and above.