### PR TITLE
Fix build configuration errors and remove empty plugin.xml

### DIFF
--- a/plugins/adapters/org.eclipse.emf.henshin.adapters.xtext/META-INF/MANIFEST.MF
+++ b/plugins/adapters/org.eclipse.emf.henshin.adapters.xtext/META-INF/MANIFEST.MF
@@ -1,6 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Henshinsupport
+Bundle-Vendor: Eclipse Modeling Project
 Bundle-SymbolicName: org.eclipse.emf.henshin.adapters.xtext;singleton:=true
 Bundle-Version: 1.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.ocl2gc/plugin.xml
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.ocl2gc/plugin.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<?eclipse version="3.4"?>
-<plugin>
-
-</plugin>

--- a/plugins/org.eclipse.emf.henshin.giraph/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.giraph/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.emf.henshin.giraph;singleton:=true
 Bundle-Version: 1.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-Localization: plugin
 Export-Package: org.eclipse.emf.henshin.giraph,
  org.eclipse.emf.henshin.giraph.templates
 Require-Bundle: org.eclipse.ant.core;bundle-version="3.2.0",

--- a/plugins/org.eclipse.emf.henshin.giraph/build.properties
+++ b/plugins/org.eclipse.emf.henshin.giraph/build.properties
@@ -1,4 +1,6 @@
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
-               .
+               .,\
+               plugin.properties,\
+               plugin.xml

--- a/plugins/org.eclipse.emf.henshin.interpreter/build.properties
+++ b/plugins/org.eclipse.emf.henshin.interpreter/build.properties
@@ -10,5 +10,4 @@ source.. = src/
 output.. = bin/
 bin.includes = .,\
                plugin.properties,\
-               META-INF/,\
-               plugin.xml
+               META-INF/

--- a/plugins/org.eclipse.emf.henshin.interpreter/plugin.xml
+++ b/plugins/org.eclipse.emf.henshin.interpreter/plugin.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<?eclipse version="3.4"?>
-<plugin>
-
-</plugin>

--- a/plugins/org.eclipse.emf.henshin.monitoring.kieker/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.monitoring.kieker/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.emf.henshin.monitoring.kieker;singleton:=true
 Bundle-Version: 1.9.0.qualifier
+Bundle-Localization: plugin
 Bundle-ClassPath: ., kieker-1.13.jar 
 Export-Package: com.beust.jcommander,
  com.beust.jcommander.converters,

--- a/plugins/org.eclipse.emf.henshin.monitoring.kieker/build.properties
+++ b/plugins/org.eclipse.emf.henshin.monitoring.kieker/build.properties
@@ -1,6 +1,7 @@
 bin.includes = .,\
                META-INF/,\
                kieker-1.13.jar,\
+               plugin.properties,\
                plugin.xml
 source.. = src/
 output.. = bin/

--- a/plugins/org.eclipse.emf.henshin.monitoring.kieker/plugin.properties
+++ b/plugins/org.eclipse.emf.henshin.monitoring.kieker/plugin.properties
@@ -1,12 +1,10 @@
 # <copyright>
-# Copyright (c) 2010-2014 Henshin developers. All rights reserved. 
+# Copyright (c) 2025-2025 Henshin developers. All rights reserved. 
 # This program and the accompanying materials are made available 
 # under the terms of the Eclipse Public License v1.0 which 
 # accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 # </copyright>
 
-bin.includes = .,\
-               META-INF/
-source.. = src/
-output.. = bin/
+pluginName=Henshin Monitoring Support
+providerName=Eclipse Modeling Project

--- a/plugins/org.eclipse.emf.henshin.monitoring.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.monitoring.ui/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.emf.henshin.monitoring.ui
 Bundle-Version: 1.9.0.qualifier
+Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.swt;bundle-version="3.105.3"
 Export-Package: org.eclipse.emf.henshin.monitoring.ui,

--- a/plugins/org.eclipse.emf.henshin.monitoring.ui/build.properties
+++ b/plugins/org.eclipse.emf.henshin.monitoring.ui/build.properties
@@ -1,4 +1,5 @@
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
-               .
+               .,\
+               plugin.properties

--- a/plugins/org.eclipse.emf.henshin.monitoring.ui/plugin.properties
+++ b/plugins/org.eclipse.emf.henshin.monitoring.ui/plugin.properties
@@ -1,10 +1,10 @@
 # <copyright>
-# Copyright (c) 2010-2014 Henshin developers. All rights reserved. 
+# Copyright (c) 2025-2025 Henshin developers. All rights reserved. 
 # This program and the accompanying materials are made available 
 # under the terms of the Eclipse Public License v1.0 which 
 # accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 # </copyright>
 
-pluginName=Henshin Rule Generation Tests
+pluginName=Henshin Monitoring UI
 providerName=Eclipse Modeling Project

--- a/plugins/org.eclipse.emf.henshin.multicda.cda/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.multicda.cda/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.emf.henshin.multicda.cda;singleton:=true
 Bundle-Version: 1.9.0.qualifier
+Bundle-Localization: plugin
 Bundle-Activator: org.eclipse.emf.henshin.multicda.cda.Activator
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources;bundle-version="3.6.0",

--- a/plugins/org.eclipse.emf.henshin.multicda.cda/build.properties
+++ b/plugins/org.eclipse.emf.henshin.multicda.cda/build.properties
@@ -1,4 +1,5 @@
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
-               .
+               .,\
+               plugin.properties

--- a/plugins/org.eclipse.emf.henshin.multicda.cpa.ui/build.properties
+++ b/plugins/org.eclipse.emf.henshin.multicda.cpa.ui/build.properties
@@ -11,7 +11,6 @@ output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\
+               plugin.properties,\
                icons/,\
                src/
-src.includes = src/
-

--- a/plugins/org.eclipse.emf.henshin.rulegen.tests/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.rulegen.tests/META-INF/MANIFEST.MF
@@ -1,10 +1,10 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: %pluginName
+Bundle-Name: Henshin Rule Generation Tests
 Bundle-SymbolicName: org.eclipse.emf.henshin.rulegen.tests;singleton:=true
 Bundle-Version: 1.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Bundle-Vendor: %providerName
+Bundle-Vendor: Eclipse Modeling Project
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.junit;bundle-version="4.12.0",
  org.eclipse.emf.henshin.tests,

--- a/plugins/org.eclipse.emf.henshin.rulegen.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.rulegen.ui/META-INF/MANIFEST.MF
@@ -3,6 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.emf.henshin.rulegen.ui;singleton:=true
 Bundle-Version: 1.9.0.qualifier
+Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.core.resources,

--- a/plugins/org.eclipse.emf.henshin.rulegen.ui/build.properties
+++ b/plugins/org.eclipse.emf.henshin.rulegen.ui/build.properties
@@ -2,4 +2,5 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
+               plugin.properties,\
                plugin.xml

--- a/plugins/org.eclipse.emf.henshin.rulegen/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.rulegen/META-INF/MANIFEST.MF
@@ -3,6 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.emf.henshin.rulegen;singleton:=true
 Bundle-Version: 1.9.0.qualifier
+Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,
  org.eclipse.emf.common,

--- a/plugins/org.eclipse.emf.henshin.rulegen/build.properties
+++ b/plugins/org.eclipse.emf.henshin.rulegen/build.properties
@@ -2,3 +2,5 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
+               plugin.properties
+

--- a/plugins/org.eclipse.emf.henshin.text.transformation.tests/build.properties
+++ b/plugins/org.eclipse.emf.henshin.text.transformation.tests/build.properties
@@ -1,4 +1,5 @@
-source.. = src/
+source.. = src/,\
+           xtend-gen/
 output.. = bin/
 bin.includes = META-INF/,\
                .

--- a/plugins/org.eclipse.emf.henshin.text.transformation/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.henshin.text.transformation/META-INF/MANIFEST.MF
@@ -4,5 +4,6 @@ Bundle-SymbolicName: org.eclipse.emf.henshin.text.transformation;singleton:=true
 Bundle-Version: 1.9.0.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
+Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.m2m.qvt.oml

--- a/plugins/org.eclipse.emf.henshin.text.transformation/build.properties
+++ b/plugins/org.eclipse.emf.henshin.text.transformation/build.properties
@@ -1,2 +1,3 @@
 bin.includes = META-INF/,\
+               plugin.properties,\
                transforms/

--- a/plugins/org.eclipse.emf.henshin.text.transformation/plugin.properties
+++ b/plugins/org.eclipse.emf.henshin.text.transformation/plugin.properties
@@ -1,12 +1,10 @@
 # <copyright>
-# Copyright (c) 2010-2014 Henshin developers. All rights reserved. 
+# Copyright (c) 2025-2025 Henshin developers. All rights reserved. 
 # This program and the accompanying materials are made available 
 # under the terms of the Eclipse Public License v1.0 which 
 # accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 # </copyright>
 
-bin.includes = .,\
-               META-INF/
-source.. = src/
-output.. = bin/
+pluginName=Henshin Text Transformations
+providerName=Eclipse Modeling Project

--- a/plugins/variability/org.eclipse.emf.henshin.variability.mergein.ui/.classpath
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.mergein.ui/.classpath
@@ -3,5 +3,5 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="output" path="org.eclipse.emf.henshin.variability.bin"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
Mainly add missing definition of 'Bundle-Localization' header and inclusion of 'plugin.properties', but also add missing or wrong source-folders.