### PR TITLE
Add .project files for henshin-ocl2ac and -variability SDK features

### DIFF
--- a/features/org.eclipse.emf.henshin.sdk.ocl2ac/.project
+++ b/features/org.eclipse.emf.henshin.sdk.ocl2ac/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.emf.henshin.sdk.ocl2ac</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.FeatureBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.FeatureNature</nature>
+	</natures>
+</projectDescription>

--- a/features/org.eclipse.emf.henshin.sdk.variability/.project
+++ b/features/org.eclipse.emf.henshin.sdk.variability/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.emf.henshin.sdk.variability</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.FeatureBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.FeatureNature</nature>
+	</natures>
+</projectDescription>


### PR DESCRIPTION
These are currently missing which makes it tedious to import the projects.