### PR TITLE
Move build to Tycho 4.0.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,10 +28,12 @@ jobs:
         distribution: 'temurin'
         java-version: |
           11
+          17
+        # This action also generates a suitable Maven toolchains.xml
     - name: Set up Maven
       uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
       with:
-        maven-version: 3.6.3
+        maven-version: 3.9.9
     - name: Cache local Maven repository
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
@@ -42,5 +44,5 @@ jobs:
           ${{ runner.os }}-maven-
     - name: Build Henshin
       run: >-
-           mvn clean verify -DskipTests --fail-at-end
+           mvn clean verify -P strict-jdk -DskipTests --fail-at-end
            --batch-mode --no-transfer-progress --threads 1C

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ bin/
 
 # Ignore temporary build artifacts
 target/
+.polyglot*
+.tycho-consumer-pom.xml
+pom.tycho
 
 /plugins/org.eclipse.emf.henshin.text/src-gen/
 /plugins/org.eclipse.emf.henshin.text/xtend-gen/

--- a/features/org.eclipse.emf.henshin.sdk.ocl2ac/feature.xml
+++ b/features/org.eclipse.emf.henshin.sdk.ocl2ac/feature.xml
@@ -35,12 +35,10 @@ http://www.eclipse.org/legal/epl-v10.html
       <import plugin="org.eclipse.core.runtime"/>
       <import plugin="org.eclipse.core.resources" version="3.9.1" match="greaterOrEqual"/>
       <import plugin="org.eclipse.emf.henshin.trace"/>
-      <import plugin="org.eclipse.ocl.ecore"/>
       <import plugin="org.eclipse.ocl.ecore" version="3.0.0" match="compatible"/>
       <import plugin="org.eclipse.emf.transaction"/>
       <import plugin="org.sat4j.core"/>
       <import plugin="org.eclipse.gmf.runtime.emf.ui.properties"/>
-      <import plugin="org.eclipse.gmf.runtime.diagram.ui"/>
       <import plugin="org.eclipse.emf.henshin.diagram"/>
       <import plugin="org.eclipse.jface.databinding"/>
       <import plugin="org.eclipse.emf.databinding"/>

--- a/features/org.eclipse.emf.henshin.sdk.ocl2ac/pom.xml
+++ b/features/org.eclipse.emf.henshin.sdk.ocl2ac/pom.xml
@@ -12,40 +12,5 @@
 
   <artifactId>org.eclipse.emf.henshin.sdk.ocl2ac</artifactId>
   <packaging>eclipse-feature</packaging>
-  <build>
-  <plugins>
-    <plugin>
-      <groupId>org.eclipse.tycho.extras</groupId>
-      <artifactId>tycho-source-feature-plugin</artifactId>
-      <version>${tycho-extras-version}</version>
-      <executions>
-        <execution>
-          <id>source-feature</id>
-          <phase>package</phase>
-          <goals>
-            <goal>source-feature</goal>
-          </goals>
-          <configuration>
-            <labelSuffix xml:space="preserve"> Sources</labelSuffix>
-         </configuration>
-        </execution>
-      </executions>
-    </plugin>
-    <plugin>
-      <groupId>org.eclipse.tycho</groupId>
-      <artifactId>tycho-p2-plugin</artifactId>
-      <version>${tycho-version}</version>
-      <executions>
-        <execution>
-          <id>attach-p2-metadata</id>
-          <phase>package</phase>
-          <goals>
-            <goal>p2-metadata</goal>
-          </goals>
-        </execution>
-      </executions>
-    </plugin>
-  </plugins>
-  </build>
 
 </project>

--- a/features/org.eclipse.emf.henshin.sdk.variability/feature.xml
+++ b/features/org.eclipse.emf.henshin.sdk.variability/feature.xml
@@ -36,12 +36,10 @@ http://www.eclipse.org/legal/epl-v10.html
       <import plugin="org.eclipse.emf.henshin.variability.mergein" version="1.0.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.core.resources" version="3.9.1" match="greaterOrEqual"/>
       <import plugin="org.eclipse.emf.henshin.trace"/>
-      <import plugin="org.eclipse.ocl.ecore"/>
       <import plugin="org.eclipse.ocl.ecore" version="3.0.0" match="compatible"/>
       <import plugin="org.eclipse.emf.transaction"/>
       <import plugin="org.sat4j.core"/>
       <import plugin="org.eclipse.gmf.runtime.emf.ui.properties"/>
-      <import plugin="org.eclipse.gmf.runtime.diagram.ui"/>
       <import plugin="org.eclipse.emf.henshin.diagram"/>
       <import plugin="org.eclipse.emf.henshin.variability.configuration" version="0.1.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.jface.databinding"/>

--- a/features/org.eclipse.emf.henshin.sdk.variability/pom.xml
+++ b/features/org.eclipse.emf.henshin.sdk.variability/pom.xml
@@ -12,40 +12,5 @@
 
   <artifactId>org.eclipse.emf.henshin.sdk.variability</artifactId>
   <packaging>eclipse-feature</packaging>
-  <build>
-  <plugins>
-    <plugin>
-      <groupId>org.eclipse.tycho.extras</groupId>
-      <artifactId>tycho-source-feature-plugin</artifactId>
-      <version>${tycho-extras-version}</version>
-      <executions>
-        <execution>
-          <id>source-feature</id>
-          <phase>package</phase>
-          <goals>
-            <goal>source-feature</goal>
-          </goals>
-          <configuration>
-            <labelSuffix xml:space="preserve"> Sources</labelSuffix>
-         </configuration>
-        </execution>
-      </executions>
-    </plugin>
-    <plugin>
-      <groupId>org.eclipse.tycho</groupId>
-      <artifactId>tycho-p2-plugin</artifactId>
-      <version>${tycho-version}</version>
-      <executions>
-        <execution>
-          <id>attach-p2-metadata</id>
-          <phase>package</phase>
-          <goals>
-            <goal>p2-metadata</goal>
-          </goals>
-        </execution>
-      </executions>
-    </plugin>
-  </plugins>
-  </build>
 
 </project>

--- a/features/org.eclipse.emf.henshin.sdk/feature.xml
+++ b/features/org.eclipse.emf.henshin.sdk/feature.xml
@@ -33,7 +33,6 @@ http://www.eclipse.org/legal/epl-v10.html
       <import plugin="org.eclipse.emf.edit" version="2.6.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.core.runtime" version="3.6.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.core.resources" version="3.6.0" match="greaterOrEqual"/>
-      <import plugin="org.eclipse.emf.ecore.xmi" version="2.5.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.emf.ecore.editor" version="2.6.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.ui.forms" version="3.5.2" match="greaterOrEqual"/>
       <import plugin="org.eclipse.core.expressions"/>

--- a/features/org.eclipse.emf.henshin.sdk/pom.xml
+++ b/features/org.eclipse.emf.henshin.sdk/pom.xml
@@ -12,45 +12,5 @@
 
   <artifactId>org.eclipse.emf.henshin.sdk</artifactId>
   <packaging>eclipse-feature</packaging>
-  <build>
-  <plugins>
-    <plugin>
-      <groupId>org.eclipse.tycho.extras</groupId>
-      <artifactId>tycho-source-feature-plugin</artifactId>
-      <version>${tycho-extras-version}</version>
-      <executions>
-        <execution>
-          <id>source-feature</id>
-          <phase>package</phase>
-          <goals>
-            <goal>source-feature</goal>
-          </goals>
-          <configuration>
-            <labelSuffix xml:space="preserve"> Sources</labelSuffix>
-            <excludes>
-              <plugin id="de.tuberlin.eecs.agg"/>
-              <plugin id="org.eclipse.emf.henshin.text.transformation"/>
-              <plugin id="org.eclipse.gmf.tooling.runtime"/>
-            </excludes>
-         </configuration>
-        </execution>
-      </executions>
-    </plugin>
-    <plugin>
-      <groupId>org.eclipse.tycho</groupId>
-      <artifactId>tycho-p2-plugin</artifactId>
-      <version>${tycho-version}</version>
-      <executions>
-        <execution>
-          <id>attach-p2-metadata</id>
-          <phase>package</phase>
-          <goals>
-            <goal>p2-metadata</goal>
-          </goals>
-        </execution>
-      </executions>
-    </plugin>
-  </plugins>
-  </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,7 @@
 	</modules>
 
 	<properties>
-		<tycho-version>1.3.0</tycho-version>
-		<tycho-extras-version>1.3.0</tycho-extras-version>
+		<tycho-version>4.0.12</tycho-version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.release>11</maven.compiler.release>
 	</properties>
@@ -115,18 +114,75 @@
 							<goal>plugin-source</goal>
 						</goals>
 					</execution>
+					<execution>
+						<id>feature-source</id>
+						<goals>
+							<goal>feature-source</goal>
+						</goals>
+						<configuration>
+							<labelSuffix xml:space="preserve"> Sources</labelSuffix>
+							<excludes>
+								<plugin id="de.tuberlin.eecs.agg"/>
+								<plugin id="org.eclipse.emf.henshin.text.transformation"/>
+								<plugin id="org.eclipse.gmf.tooling.runtime"/>
+							</excludes>
+						</configuration>
+					</execution>
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.1</version>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-plugin</artifactId>
+				<version>${tycho-version}</version>
 				<configuration>
-					<compilerVersion>1.14</compilerVersion>
+					<defaultP2Metadata>false</defaultP2Metadata>
 				</configuration>
+				<executions>
+					<execution>
+						<id>attach-p2-metadata</id>
+						<goals>
+							<goal>p2-metadata</goal>
+						</goals>
+						<phase>package</phase>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>strict-jdk</id>
+			<!-- Activating this profile ensures that all projects are built and tested with a JDK
+				of the exact same version as specified as their required execution environment.
+				To make this possible the Maven toolchain.xml file has to be setup accordingly the computer running the build:
+				- https://maven.apache.org/plugins/maven-toolchains-plugin/toolchains/jdk.html
+				- https://maven.apache.org/guides/mini/guide-using-toolchains.html
+				- https://tycho.eclipseprojects.io/doc/latest/tycho-compiler-plugin/compile-mojo.html#useJDK
+				- https://tycho.eclipseprojects.io/doc/latest/tycho-surefire-plugin/test-mojo.html#useJDK
+			-->
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>tycho-compiler-plugin</artifactId>
+						<version>${tycho-version}</version>
+						<configuration>
+							<useJDK>BREE</useJDK>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>tycho-surefire-plugin</artifactId>
+						<version>${tycho-version}</version>
+						<configuration>
+							<useJDK>BREE</useJDK>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 
 	<distributionManagement>
 		<repository>


### PR DESCRIPTION
Because Tycho-4 requires Java-17 to run, a special profile named 'strict-jdk' is added, which configures the tycho-compiler and tycho-surefire plugins to use a real Java-11 JDK for compiling the projects and running the tests.

- Adapt generation of source-features to the new Tycho version.
- Remove duplicated declarations of imported plugins from features
  - This is an errors in Tycho-4
- Remove declaration of unused maven-compiler-plugin.

Part of
- https://github.com/eclipse-henshin/henshin/issues/5