### PR TITLE
Update Target-Platform to Eclipse 2018-12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,5 +44,5 @@ jobs:
           ${{ runner.os }}-maven-
     - name: Build Henshin
       run: >-
-           mvn clean verify -P strict-jdk -DskipTests --fail-at-end
+           mvn clean verify -P strict-jdk --fail-at-end
            --batch-mode --no-transfer-progress --threads 1C

--- a/releng/org.eclipse.emf.henshin.target/org.eclipse.emf.henshin.target.target
+++ b/releng/org.eclipse.emf.henshin.target/org.eclipse.emf.henshin.target.target
@@ -4,7 +4,7 @@
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="de.tuberlin.eecs.agg"/>
-			<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20160520211859/repository/"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20181128170323/repository/"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.sdk.feature.group"/>
@@ -18,7 +18,7 @@
 			<unit id="org.eclipse.emf.query.sdk.feature.group"/>
 			<unit id="org.eclipse.xtext.sdk.feature.group"/>
 			<unit id="org.apache.commons.io"/>
-			<repository location="http://download.eclipse.org/releases/oxygen"/>
+			<repository location="https://download.eclipse.org/releases/2018-12/"/>
 		</location>
 	</locations>
 </target>


### PR DESCRIPTION
This allows to enable the execution of Henshin's tests again, because Eclipse 2018-12 is the first version to support Java-11.

Part of
- https://github.com/eclipse-henshin/henshin/issues/5