### PR TITLE
[Build] Add quality-gates and log tests in Jenkins pipeline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,10 +57,11 @@
 	</modules>
 
 	<properties>
+		<java-release>11</java-release>
 		<tycho-version>4.0.12</tycho-version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<java.source.release>11</java.source.release>
-		<maven.compiler.release>${java.source.release}</maven.compiler.release>
+		<maven.compiler.release>${java-release}</maven.compiler.release>
+		<compileLogDir>${project.build.directory}/compilelogs</compileLogDir>
 	</properties>
 
 	<build>
@@ -106,6 +107,22 @@
 
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-compiler-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<log>xml</log>
+					<logDirectory>${compileLogDir}</logDirectory>
+					<showWarnings>true</showWarnings>
+					<showDeprecation>true</showDeprecation>
+					<compilerArgs>
+						<arg>-enableJavadoc</arg>
+						<arg>-verbose</arg>
+					</compilerArgs>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-source-plugin</artifactId>
 				<version>${tycho-version}</version>
 				<executions>
@@ -137,6 +154,8 @@
 				<version>${tycho-version}</version>
 				<configuration>
 					<defaultP2Metadata>false</defaultP2Metadata>
+					<enhanceLogs>true</enhanceLogs>
+					<logDirectory>${compileLogDir}</logDirectory>
 				</configuration>
 				<executions>
 					<execution>
@@ -162,7 +181,7 @@
 						</goals>
 						<configuration>
 							<outputDirectory>xtend-gen</outputDirectory>
-							<javaSourceVersion>${java.source.release}</javaSourceVersion>
+							<javaSourceVersion>${java-release}</javaSourceVersion>
 						</configuration>
 					</execution>
 				</executions>
@@ -186,7 +205,6 @@
 					<plugin>
 						<groupId>org.eclipse.tycho</groupId>
 						<artifactId>tycho-compiler-plugin</artifactId>
-						<version>${tycho-version}</version>
 						<configuration>
 							<useJDK>BREE</useJDK>
 						</configuration>
@@ -197,6 +215,60 @@
 						<version>${tycho-version}</version>
 						<configuration>
 							<useJDK>BREE</useJDK>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>javadoc</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-javadoc-plugin</artifactId>
+						<version>3.11.2</version>
+						<executions>
+							<execution>
+								<id>generate-javadoc</id>
+								<goals>
+									<goal>javadoc-no-fork</goal>
+								</goals>
+								<phase>process-classes</phase>
+							</execution>
+						</executions>
+						<configuration>
+							<source>${java-release}</source>
+							<legacyMode>true</legacyMode>
+							<doclint>reference,html,syntax</doclint>
+							<notimestamp>true</notimestamp>
+							<locale>en</locale>
+							<failOnError>false</failOnError>
+							<quiet>true</quiet>
+							<tags>
+								<!-- PDE API-tools javadoc annotations currently used -->
+								<tag>
+									<name>noextend</name>
+									<placement>a</placement>
+									<head>Restriction:</head>
+								</tag>
+								<!-- EMF tags -->
+								<tag>
+									<name>model</name>
+									<placement>X</placement>
+									<head>EMF generated tag</head>
+								</tag>
+								<tag>
+									<name>generated</name>
+									<placement>X</placement>
+									<head>EMF generated tag</head>
+								</tag>
+								<tag>
+									<name>ordered</name>
+									<placement>X</placement>
+									<head>EMF generated tag</head>
+								</tag>
+							</tags>
 						</configuration>
 					</plugin>
 				</plugins>


### PR DESCRIPTION
Enable the creation of required compiler logs and enable the display of warnings in them so that they can be considered in the quality-gates.

Also don't fail the entire build on test-failures but let Jenkins record all tests and mark the build as unstable (instead of just failed) in case tests fail.

Besides the two states 'success' and 'failed' the Jenkins build also has the third state 'unstable' that is entered if the actual build succeeds and only tests have failed or the qulity-gate was missed. This means that the build only reaches the failed state on more severe problems like compile-errors, which makes the quick assessment of problems easier.

In order to allow the verification of javadoc correctness this also adds a profile to build javadoc for henshin. This slows down the build considerably and is therefore only enabled for the Jenkins build. I'll look into implementing a faster solution and will create a follow-up in case I found one.

Part of
- https://github.com/eclipse-henshin/henshin/issues/5

Follow-up on
- https://github.com/eclipse-henshin/henshin/pull/20