### PR TITLE
[Build] Disable Linux axis in GH verification build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
 


### PR DESCRIPTION
Because this project is now also build with a Jenkins pipeline, which already runs on Linux, having a Linux build in the Github workflow is not necessary anymore.

Part of
- https://github.com/eclipse-henshin/henshin/issues/5