### PR TITLE
Fix all javadoc problems

### DIFF
--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.gc2ac/src/org/eclipse/emf/henshin/ocl2ac/gc2ac/core/NestedConditionPreparer.java
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.gc2ac/src/org/eclipse/emf/henshin/ocl2ac/gc2ac/core/NestedConditionPreparer.java
@@ -61,10 +61,6 @@ public class NestedConditionPreparer {
 		return false;
 	}
 
-	/**
-	 * 
-	 * @return
-	 */
 	public boolean eliminateForAllANotExistsC() {
 		NestedCondition condition = constraint.getCondition();
 		if (isOfFormForAllANotExistsC(condition)) {
@@ -84,11 +80,6 @@ public class NestedConditionPreparer {
 		return false;
 	}
 
-	/**
-	 * 
-	 * @param condition
-	 * @return
-	 */
 	public boolean isOfFormForAllANotExistsC(NestedCondition condition) {
 		if (isForAllCondition(condition)) {
 			QuantifiedCondition forallCondition = (QuantifiedCondition) condition;
@@ -106,11 +97,6 @@ public class NestedConditionPreparer {
 		return false;
 	}
 
-	/**
-	 * 
-	 * @param condition
-	 * @return
-	 */
 	public boolean isOfFormNotExistsC(NestedCondition condition) {
 		if (isNotFormula(condition)) {
 			Formula notFormula = (Formula) condition;
@@ -124,11 +110,6 @@ public class NestedConditionPreparer {
 		return false;
 	}
 
-	/**
-	 * 
-	 * @param condition
-	 * @return
-	 */
 	public boolean isOfFormExistsC(NestedCondition condition) {
 		if (isExistCondition(condition)) {
 			QuantifiedCondition existCondition = (QuantifiedCondition) condition;

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.gc2ac/src/org/eclipse/emf/henshin/ocl2ac/gc2ac/util/RuleClassifier.java
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.gc2ac/src/org/eclipse/emf/henshin/ocl2ac/gc2ac/util/RuleClassifier.java
@@ -89,10 +89,6 @@ public class RuleClassifier {
 				+ forbidActionElements.size() + preserveActionElements.size();
 	}
 
-	/**
-	 * 
-	 * @return
-	 */
 	public boolean doesRuleCreateOnly() {
 		if (createActionElements != null) {
 			if (deleteActionElements.size() == 0 && forbidActionElements.size() == 0
@@ -102,10 +98,6 @@ public class RuleClassifier {
 		return false;
 	}
 
-	/**
-	 * 
-	 * @return
-	 */
 	public boolean doesRuleDeleteOnly() {
 		if (deleteActionElements != null) {
 			if (createActionElements.size() == 0 && forbidActionElements.size() == 0

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.ocl2gc/src/org/eclipse/emf/henshin/ocl2ac/ocl2gc/util/JointPairs.java
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.ocl2gc/src/org/eclipse/emf/henshin/ocl2ac/ocl2gc/util/JointPairs.java
@@ -38,18 +38,12 @@ public class JointPairs {
 	 * for finding the nodes which have to be overlapped. Compute the set of
 	 * jointly surjective pairs that commute with a given span.
 	 * 
-	 * @param span
-	 *            A span of morphisms
-	 * @return the set of jointly surjective pairs that commute with the span
-	 * 
 	 */
 
 	private static Pair pushout = null;
 
 	/**
 	 * for now it should be called after calling the method getJointPairs
-	 * 
-	 * @return
 	 */
 	public static Pair getPushout() {
 		return pushout;

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/src/org/eclipse/emf/henshin/ocl2ac/tool/commands/OCL2LaxCondCommand.java
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/src/org/eclipse/emf/henshin/ocl2ac/tool/commands/OCL2LaxCondCommand.java
@@ -78,8 +78,6 @@ public class OCL2LaxCondCommand extends Translator {
 
 	/**
 	 * The entry point
-	 * 
-	 * @return
 	 */
 	public List<Condition> getSetofLaxConditions() {
 		long start = System.currentTimeMillis();

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/src/org/eclipse/emf/henshin/ocl2ac/tool/optimizer/IntegrationChecker.java
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/src/org/eclipse/emf/henshin/ocl2ac/tool/optimizer/IntegrationChecker.java
@@ -33,10 +33,6 @@ public class IntegrationChecker {
 
 	/**
 	 * The official ones
-	 * 
-	 * @param rule
-	 * @param nestedConstraint
-	 * @return
 	 */
 	public boolean mustIntegrate(Rule rule, NestedConstraint nestedConstraint) {
 
@@ -140,13 +136,6 @@ public class IntegrationChecker {
 			return true;
 	}
 
-	/**
-	 * 
-	 * 
-	 * @param rule
-	 * @param condition
-	 * @return
-	 */
 	public boolean mustIntegrateWithoutAttribute(Rule rule, Condition condition) {
 
 		EList<Node> createActionNodes = rule.getActionNodes(new Action(Action.Type.CREATE));

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/src/org/eclipse/emf/henshin/ocl2ac/tool/ui/SWTResourceManager.java
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/src/org/eclipse/emf/henshin/ocl2ac/tool/ui/SWTResourceManager.java
@@ -36,9 +36,10 @@ import org.eclipse.swt.widgets.Display;
  * <code>dispose()</code> method to release the operating system resources
  * managed by cached objects when those objects and OS resources are no longer
  * needed (e.g. on application shutdown)
+ * </p>
  * <p>
  * This class may be freely distributed as part of any application or plugin.
- * <p>
+ * </p>
  * 
  * @author scheglov_ke
  * @author Dan Rubel

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/src/org/eclipse/emf/henshin/ocl2ac/tool/ui/WizardGC2AppCond.java
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/src/org/eclipse/emf/henshin/ocl2ac/tool/ui/WizardGC2AppCond.java
@@ -49,9 +49,6 @@ public class WizardGC2AppCond extends Shell {
 
 	/**
 	 * Create the shell.
-	 * 
-	 * @param display
-	 * @param mapAllRules
 	 */
 	public WizardGC2AppCond(final Display display, IFile henshinFile,
 			HashMap<Integer, NestedConstraint> hashmapAllNestedconstraints, HashMap<Integer, Rule> hashmapAllRules,

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/src/org/eclipse/emf/henshin/ocl2ac/tool/ui/WizardLaxCond2AppCond.java
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/src/org/eclipse/emf/henshin/ocl2ac/tool/ui/WizardLaxCond2AppCond.java
@@ -50,9 +50,6 @@ public class WizardLaxCond2AppCond extends Shell {
 
 	/**
 	 * Create the shell.
-	 * 
-	 * @param display
-	 * @param mapAllRules
 	 */
 	public WizardLaxCond2AppCond(final Display display, IFile henshinFile,
 			HashMap<Integer, Condition> hashmapAllLaxCondition, HashMap<Integer, Rule> hashmapAllRules,

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/src/org/eclipse/wb/swt/SWTResourceManager.java
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/src/org/eclipse/wb/swt/SWTResourceManager.java
@@ -36,9 +36,10 @@ import org.eclipse.swt.widgets.Display;
  * <code>dispose()</code> method to release the operating system resources
  * managed by cached objects when those objects and OS resources are no longer
  * needed (e.g. on application shutdown)
+ * </p>
  * <p>
  * This class may be freely distributed as part of any application or plugin.
- * <p>
+ * </p>
  * 
  * @author scheglov_ke
  * @author Dan Rubel

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.utils/src/org/eclipse/emf/henshin/ocl2ac/utils/henshin/simplification/EquivalencesSimplifier.java
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.utils/src/org/eclipse/emf/henshin/ocl2ac/utils/henshin/simplification/EquivalencesSimplifier.java
@@ -686,13 +686,6 @@ public class EquivalencesSimplifier {
 		return eClasses;
 	}
 
-	/**
-	 * 
-	 * 
-	 * @param graphA
-	 * @param graphB
-	 * @return
-	 */
 	public boolean isSubGraph(Graph graphA, Graph graphB) {
 		HashMap<Node, Node> mappingNodeA2NodeB = new HashMap<Node, Node>();
 		for (Node nodeA : graphA.getNodes()) {

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.utils/src/org/eclipse/emf/henshin/ocl2ac/utils/henshin/simplification/HenshinNACSimplifier.java
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.utils/src/org/eclipse/emf/henshin/ocl2ac/utils/henshin/simplification/HenshinNACSimplifier.java
@@ -435,13 +435,6 @@ public class HenshinNACSimplifier {
 		return null;
 	}
 
-	/**
-	 * 
-	 * 
-	 * @param graphA
-	 * @param graphB
-	 * @return
-	 */
 	public static boolean isSubGraph(Graph graphA, Graph graphB) {
 		HashMap<Node, Node> mappingNodeA2NodeB = new HashMap<Node, Node>();
 		for (Node nodeA : graphA.getNodes()) {

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/commands/AttributeDeleteCommand.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/commands/AttributeDeleteCommand.java
@@ -32,7 +32,7 @@ public class AttributeDeleteCommand extends AbstractTransactionalCommand {
 	/**
 	 * Default constructor.
 	 * @param domain Editing domain.
-	 * @param edge Edge to be deleted.
+	 * @param attribute Attribute to be deleted.
 	 */
 	public AttributeDeleteCommand(TransactionalEditingDomain domain, Attribute attribute) {
 		super(domain, "Delete Attribute", null);

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/commands/NodeCreateCommand.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/commands/NodeCreateCommand.java
@@ -269,8 +269,6 @@ public class NodeCreateCommand extends EditElementCommand {
 		 * Opens the dialog and returns the first selected EClass in the
 		 * list. If no EClass is available in the module or
 		 * the dialog is canceled, null is returned.
-		 * 
-		 * @return
 		 */
 		public final EClass openAndReturnSelection() {
 

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/helpers/RootObjectEditHelper.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/helpers/RootObjectEditHelper.java
@@ -146,8 +146,7 @@ public class RootObjectEditHelper {
 	}
 	
 	/**
-	 * Set the root object type for a rule. Before doing this you should make sure that
-	 * the root object type is ok using {@link #isPossibleRootType(EClass, Rule)}.
+	 * Set the root object type for a rule.
 	 * @param ruleView The rule view.
 	 * @param type Root object type.
 	 * @throws ExecutionException On errors.

--- a/plugins/org.eclipse.emf.henshin.edit/src/org/eclipse/emf/henshin/commands/dnd/DelegatingWrapperFeatureDragAndDropCommand.java
+++ b/plugins/org.eclipse.emf.henshin.edit/src/org/eclipse/emf/henshin/commands/dnd/DelegatingWrapperFeatureDragAndDropCommand.java
@@ -70,7 +70,6 @@ public class DelegatingWrapperFeatureDragAndDropCommand extends AbstractCommand 
 	/**
 	 * @param domain
 	 * @param owner
-	 * @param feature
 	 * @param collection
 	 */
 	public DelegatingWrapperFeatureDragAndDropCommand(EditingDomain domain, Object owner,

--- a/plugins/org.eclipse.emf.henshin.edit/src/org/eclipse/emf/henshin/provider/trans/TransientItemProvider.java
+++ b/plugins/org.eclipse.emf.henshin.edit/src/org/eclipse/emf/henshin/provider/trans/TransientItemProvider.java
@@ -116,12 +116,6 @@ public class TransientItemProvider extends ItemProviderAdapter implements
 				super.createAddCommand(domain, owner, feature, collection, index), owner);
 	}// createAddCommand
 	
-	/**
-	 * @param command
-	 * @param owner
-	 * @param feature
-	 * @return
-	 */
 	protected Command createWrappedCommand(Command command, final EObject owner) {
 		return new CommandWrapper(command) {
 			public Collection<?> getAffectedObjects() {

--- a/plugins/org.eclipse.emf.henshin.edit/src/org/eclipse/emf/henshin/provider/util/IconUtil.java
+++ b/plugins/org.eclipse.emf.henshin.edit/src/org/eclipse/emf/henshin/provider/util/IconUtil.java
@@ -26,7 +26,6 @@ public class IconUtil {
 	 * 
 	 * @param baseImage
 	 * @param overlayImage
-	 * @return
 	 */
 	public static Object getCompositeImage(Object baseImage, Object overlayImage) {
 		List<Object> images = new ArrayList<Object>(2);
@@ -46,7 +45,6 @@ public class IconUtil {
 	 * @param overlayImage
 	 * @param moveX
 	 * @param moveY
-	 * @return
 	 */
 	public static Object getCompositeImage(Object baseImage, Object overlayImage, final int moveX,
 			final int moveY) {

--- a/plugins/org.eclipse.emf.henshin.editor/src/org/eclipse/emf/henshin/editor/commands/CreateParameterMappingCommand.java
+++ b/plugins/org.eclipse.emf.henshin.editor/src/org/eclipse/emf/henshin/editor/commands/CreateParameterMappingCommand.java
@@ -42,8 +42,6 @@ public class CreateParameterMappingCommand extends AbstractCommand {
 	/**
 	 * Checks if a parameter mappings already exists. This method shall hint the
 	 * wrapping action to appear enabled or disabled.
-	 * 
-	 * @return
 	 */
 	public boolean isEnabled() {
 		if (this.canExecute()) {

--- a/plugins/org.eclipse.emf.henshin.editor/src/org/eclipse/emf/henshin/editor/util/HtmlTipSupport.java
+++ b/plugins/org.eclipse.emf.henshin.editor/src/org/eclipse/emf/henshin/editor/util/HtmlTipSupport.java
@@ -112,10 +112,7 @@ public class HtmlTipSupport {
 	/**
 	 * This method must be called after the viewer's {@link LabelProvider} is
 	 * set.
-	 * 
-	 * @param viewer
 	 */
-	
 	protected TreeItem getItem(MouseEvent e) {
 		return viewer.getTree().getItem(new Point(e.x, e.y));
 	}

--- a/plugins/org.eclipse.emf.henshin.editor/src/org/eclipse/emf/henshin/editor/util/IToolTipProvider.java
+++ b/plugins/org.eclipse.emf.henshin.editor/src/org/eclipse/emf/henshin/editor/util/IToolTipProvider.java
@@ -11,7 +11,7 @@ package org.eclipse.emf.henshin.editor.util;
 
 /**
  * Implementation interface for ToolTipProviders as required by
- * {@link TreeViewerToolTipSupport}.
+ * {@link HtmlTipSupport}.
  * 
  * @author Gregor Bonifer
  * 

--- a/plugins/org.eclipse.emf.henshin.examples/src/org/eclipse/emf/henshin/examples/bankmap/BankMapExample.java
+++ b/plugins/org.eclipse.emf.henshin.examples/src/org/eclipse/emf/henshin/examples/bankmap/BankMapExample.java
@@ -41,7 +41,6 @@ public class BankMapExample {
 	/**
 	 * Run the bank example.
 	 * @param path Relative path to the model files.
-	 * @param saveResult Whether the result should be saved.
 	 */
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public static void run(String path) {

--- a/plugins/org.eclipse.emf.henshin.examples/src/org/eclipse/emf/henshin/examples/metamodelevolution/Evolution1.java
+++ b/plugins/org.eclipse.emf.henshin.examples/src/org/eclipse/emf/henshin/examples/metamodelevolution/Evolution1.java
@@ -339,7 +339,6 @@ public class Evolution1 {
 	 * @param refType
 	 *            Type (EReference) of the reference to be deleted. Its opposite
 	 *            is deduced and deleted as well.
-	 * @return
 	 */
 	public UnitApplication evolveMetaModel_DeleteOldReference(EPackage petri,
 			EReference refType) {

--- a/plugins/org.eclipse.emf.henshin.interpreter.ui/src/org/eclipse/emf/henshin/interpreter/ui/HenshinInterpreterUIPlugin.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter.ui/src/org/eclipse/emf/henshin/interpreter/ui/HenshinInterpreterUIPlugin.java
@@ -48,7 +48,6 @@ public class HenshinInterpreterUIPlugin extends EMFPlugin {
 	/**
 	 * Non-breaking property access.
 	 * @param key
-	 * @return
 	 */
 	public static String LL(String key) {
 		try {

--- a/plugins/org.eclipse.emf.henshin.interpreter.ui/src/org/eclipse/emf/henshin/interpreter/ui/debug/ParamUtil.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter.ui/src/org/eclipse/emf/henshin/interpreter/ui/debug/ParamUtil.java
@@ -19,8 +19,6 @@ public class ParamUtil {
 
 	/**
 	 * finds the IFile at the location provided by the string uri
-	 * @param uriString
-	 * @return
 	 */
 	public static IFile getIFile(URI uri) {
 		try {
@@ -37,7 +35,6 @@ public class ParamUtil {
 	/**
 	 * gets the parameter preferences from a given unit
 	 * @param unit
-	 * @return
 	 */
 	public static List<ParameterConfig> getParameterPreferences(Unit unit) {
 		List<ParameterConfig> result = new ArrayList<ParameterConfig>();

--- a/plugins/org.eclipse.emf.henshin.interpreter.ui/src/org/eclipse/emf/henshin/interpreter/ui/wizard/ModelSelector.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter.ui/src/org/eclipse/emf/henshin/interpreter/ui/wizard/ModelSelector.java
@@ -153,9 +153,6 @@ public class ModelSelector {
 		}
 	}
 
-	/**
-	 * @return
-	 */
 	public Control getControl() {
 		return container;
 	}

--- a/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/ApplicationMonitor.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/ApplicationMonitor.java
@@ -51,7 +51,7 @@ public interface ApplicationMonitor {
 	 * @param application Undone unit application.
 	 * @param success Whether the unit application was successfully undone.
 	 */
-	void notifyUndo(UnitApplication application, boolean succeess);
+	void notifyUndo(UnitApplication application, boolean success);
 
 	/**
 	 * Notify this monitor that a unit application has been redone.

--- a/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/InterpreterFactory.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/InterpreterFactory.java
@@ -41,7 +41,7 @@ public interface InterpreterFactory {
 	
 	/**
 	 * Create a {@link Match}.
-	 * @param Rule to be matched.
+	 * @param rule to be matched.
 	 * @param isResultMatch Determines whether this is a result match.
 	 * @return A new {@link Match}.
 	 */

--- a/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/UnitApplication.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/UnitApplication.java
@@ -89,7 +89,7 @@ public interface UnitApplication {
 	
 	/**
 	 * Undo this unit application. This restores the original model as
-	 * it was before calling {@link #execute()}.
+	 * it was before calling {@link #execute(ApplicationMonitor)}.
 	 * @param monitor The application monitor or <code>null</code>.
 	 * @return <code>true</code> if the unit was successfully undone.
 	 */
@@ -97,7 +97,7 @@ public interface UnitApplication {
 	
 	/**
 	 * Redo this unit application. This method can be invoked after
-	 * {@link #undo()} has been invoked. The effect is that the
+	 * {@link #undo(ApplicationMonitor)} has been invoked. The effect is that the
 	 * unit is executed again.
 	 * @param monitor The application monitor or <code>null</code>.
 	 * @return <code>true</code> if the unit was successfully redone.

--- a/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/debug/HenshinDebugTarget.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/debug/HenshinDebugTarget.java
@@ -36,7 +36,7 @@ public class HenshinDebugTarget extends HenshinDebugElement implements IDebugTar
 	/**
 	 * HenshinDebugTarget Constructor. <br>
 	 * NOTE: The associated debugThread has to be set separately
-	 * using {@link #initTarget(DebugApplicationCondition)}.
+	 * using {@link #initTarget(DebugApplicationCondition, IResource)}.
 	 * @param launch
 	 * @param ruleName
 	 */

--- a/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/debug/HenshinDebugValue.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/debug/HenshinDebugValue.java
@@ -36,9 +36,7 @@ public abstract class HenshinDebugValue extends HenshinDebugElement implements I
 	 * </ol>
 	 * @param target the associated debug target
 	 * @param graph an {@link EGraph} that is used to retrieve a string label for this value, or <code>null</code>
-	 * @param valueObject the actual value. If null, the valueString will be used as value object
 	 * @param declaredType the string representation of the value's declared type.
-	 * @param indexInDomain the index within the domain
 	 */
 	public HenshinDebugValue(IDebugTarget target, EGraph graph, String declaredType) {
 		super(target);
@@ -87,7 +85,7 @@ public abstract class HenshinDebugValue extends HenshinDebugElement implements I
 
 	/**
 	 * checks whether an EAttribute is of a primitive (meta) type
-	 * @param attribute the attribute to check
+	 * @param object the object to check
 	 * @return <code>true</code> if the attribute is primitive
 	 */
 	public boolean isPrimitive(EObject object) {

--- a/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/impl/AssignmentImpl.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/impl/AssignmentImpl.java
@@ -37,7 +37,6 @@ public class AssignmentImpl implements Assignment {
 	
 	/**
 	 * Default constructor.
-	 * @param rule Rule to be matched.
 	 */
 	public AssignmentImpl(Unit unit) {
 		this (unit, false);

--- a/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/impl/ChangeImpl.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/impl/ChangeImpl.java
@@ -55,7 +55,7 @@ public abstract class ChangeImpl implements Change {
 	}
 	
 	/**
-	 * Default implementation of {@link ObjectChange}.
+	 * Default implementation of {@link org.eclipse.emf.henshin.interpreter.Change.ObjectChange}.
 	 * @author Christian Krause
 	 */
 	public static final class ObjectChangeImpl extends ChangeImpl implements ObjectChange {
@@ -104,7 +104,7 @@ public abstract class ChangeImpl implements Change {
 	}
 	
 	/**
-	 * Default implementation of {@link AttributeChange}.
+	 * Default implementation of {@link org.eclipse.emf.henshin.interpreter.Change.AttributeChange}.
 	 * @author Christian Krause
 	 */
 	public static final class AttributeChangeImpl extends ChangeImpl implements AttributeChange {
@@ -211,7 +211,7 @@ public abstract class ChangeImpl implements Change {
 	}
 	
 	/**
-	 * Default implementation of {@link ReferenceChange}.
+	 * Default implementation of {@link org.eclipse.emf.henshin.interpreter.Change.ReferenceChange}.
 	 * @author Christian Krause
 	 */
 	public static final class ReferenceChangeImpl extends ChangeImpl implements ReferenceChange {
@@ -340,7 +340,7 @@ public abstract class ChangeImpl implements Change {
 	}
 
 	/**
-	 * Default implementation of {@link IndexChange}.
+	 * Default implementation of {@link org.eclipse.emf.henshin.interpreter.Change.IndexChange}.
 	 * @author Christian Krause
 	 */
 	public static final class IndexChangeImpl extends ChangeImpl implements IndexChange {
@@ -448,7 +448,7 @@ public abstract class ChangeImpl implements Change {
 	}
 	
 	/**
-	 * Default implementation of {@link CompoundChange}.
+	 * Default implementation of {@link org.eclipse.emf.henshin.interpreter.Change.CompoundChange}.
 	 * @author Christian Krause
 	 */
 	public static final class CompoundChangeImpl extends ChangeImpl implements CompoundChange {

--- a/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/impl/Debugger.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/impl/Debugger.java
@@ -81,9 +81,8 @@ public class Debugger extends Interpreter {
 	 * Executes a Transformation-Rule on a given Match
 	 * @param graph The Graph to transform
 	 * @param mod The Module containing the Rule
-	 * @param rule The Name of the Rule
-	 * @param partial the Partial Match(can be null)
-	 * @param complete the complete Match
+	 * @param ruleName The Name of the Rule
+	 * @param match the match(can be null)
 	 * @param parameterValues the Values of the Rules' Parameters.
 	 * @return true - if the Rule was successfully applied. false - Otherwise
 	 */

--- a/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/impl/Interpreter.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/impl/Interpreter.java
@@ -33,7 +33,7 @@ public class Interpreter {
 	 * Executes a Unit with the given ParameterValues on the given Graph
 	 * @param graph The Graph to execute the transformation on
 	 * @param mod The Module that contains the Unit
-	 * @param unit The Name of the Unit
+	 * @param unitName The Name of the Unit
 	 * @param parameterValues List of ParameterValues using "Object..." syntax. Has to be in same order as all the "in" Parameters of the specified Unit!
 	 * @return the transformed EGraph
 	 */
@@ -112,7 +112,7 @@ public class Interpreter {
 
 	/**
 	 * Returns the Results of the specified Parameter of the last executed Unit
-	 * @param the Name of the Parameter
+	 * @param param the Name of the Parameter
 	 * @return the Parameter Value
 	 */
 	public Object getResultParameterValue(String param) {

--- a/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/matching/conditions/ConditionHandler.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/matching/conditions/ConditionHandler.java
@@ -45,7 +45,6 @@ public class ConditionHandler {
 	 * @param conditionParameters Condition parameters.
 	 * @param scriptEngine Script engine,
 	 * @param localJavaImports 
-	 * @param javaImports 
 	 */
 	public ConditionHandler(
 			Map<String, Collection<String>> conditionParameters,

--- a/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/matching/conditions/ConstraintInstanceBreakpoint.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/matching/conditions/ConstraintInstanceBreakpoint.java
@@ -6,7 +6,6 @@ public class ConstraintInstanceBreakpoint extends HenshinBreakpoint {
 
 	/**
 	 * Retrieve the brekpoint's type. (type of the value we set the breakpoint for)
-	 * @return
 	 */
 	public String getConstraintInstance() {
 		return getAttribute("ConstraintInstance", "");

--- a/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/matching/conditions/ConstraintTypeBreakpoint.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/matching/conditions/ConstraintTypeBreakpoint.java
@@ -7,7 +7,6 @@ public class ConstraintTypeBreakpoint extends HenshinBreakpoint {
 
 	/**
 	 * Retrieve the brekpoint's type. (type of the value we set the breakpoint for)
-	 * @return
 	 */
 	public ConstraintType getType() {
 		return ConstraintType.valueOf(getAttribute("Type", ConstraintType.NONE.toString()));

--- a/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/matching/conditions/DebugApplicationCondition.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/matching/conditions/DebugApplicationCondition.java
@@ -35,6 +35,7 @@ import org.eclipse.emf.henshin.interpreter.debug.HenshinStackFrame;
 import org.eclipse.emf.henshin.interpreter.info.RuleInfo;
 import org.eclipse.emf.henshin.interpreter.matching.constraints.AttributeConstraint;
 import org.eclipse.emf.henshin.interpreter.matching.constraints.BinaryConstraint;
+import org.eclipse.emf.henshin.interpreter.matching.constraints.Constraint;
 import org.eclipse.emf.henshin.interpreter.matching.constraints.ContainmentConstraint;
 import org.eclipse.emf.henshin.interpreter.matching.constraints.DanglingConstraint;
 import org.eclipse.emf.henshin.interpreter.matching.constraints.DomainSlot;
@@ -279,7 +280,6 @@ public class DebugApplicationCondition extends ApplicationCondition {
 	/**
 	 * Tries to find another constraint type that has to be checked.
 	 * If not, tries to continue to the next variable because all constraints for this variable are valid
-	 * @return
 	 */
 	private synchronized void tryNextConstraintType() {
 		//are there any constraint types (with constraints) left that we have to check?
@@ -299,7 +299,6 @@ public class DebugApplicationCondition extends ApplicationCondition {
 	
 	/**
 	 * Tries to go to the next value. Calls {@link #tryLowerIndexVariable()} if no value is left
-	 * @return
 	 */
 	private void tryNextValue() {
 		// are any other values left for this variable?
@@ -327,7 +326,6 @@ public class DebugApplicationCondition extends ApplicationCondition {
 	/**
 	 * Tries to go to the next Variable with a lower index (shallower recursion depth)
 	 * to continue the search for a match.
-	 * @return
 	 */
 	private void tryLowerIndexVariable() {
 		// clear (+ unlock) the current domain slot
@@ -1016,7 +1014,6 @@ public void stepReturn() throws DebugException {
 	/**
 	 * Filter all constraint type breakpoints and returns an array list.
 	 * @param henshinBreakpoints
-	 * @return
 	 */
 	public ArrayList<ConstraintTypeBreakpoint> filterConstraintTypeBreakpoints(ArrayList<HenshinBreakpoint> henshinBreakpoints) {
 		ArrayList<ConstraintTypeBreakpoint> constraintTypeBreakpoints = new ArrayList<ConstraintTypeBreakpoint>();
@@ -1044,7 +1041,6 @@ public void stepReturn() throws DebugException {
 	/**
 	 * Filter all constraint instance breakpoints and returns an array list.
 	 * @param henshinBreakpoints
-	 * @return
 	 */
 	public ArrayList<ConstraintInstanceBreakpoint> filterConstraintInstanceBreakpoints(ArrayList<HenshinBreakpoint> henshinBreakpoints) {
 		ArrayList<ConstraintInstanceBreakpoint> constraintInstanceBreakpoints = new ArrayList<ConstraintInstanceBreakpoint>();
@@ -1116,10 +1112,6 @@ public void stepReturn() throws DebugException {
 	 * Checks if the application should suspend at the given ValueBreakpoint.
 	 * Therefore we check if the value we saved in the ValueBreakpoint is a member of the domain
 	 * and if so we additionally check if the saved index matches the index of the value within the domain.
-	 * 
-	 * @param variableBreakpoint
-	 * @param domain
-	 * @return boolean
 	 */
 	public boolean shouldStopAtValueBreakpoint(ValueBreakpoint valueBreakpoint, EObject value, int index) {
 		try {
@@ -1145,20 +1137,10 @@ public void stepReturn() throws DebugException {
 		return false;
 	}
 	
-	/**
-	 * 
-	 * @param constraintTypeBreakpoint
-	 * @return
-	 */
 	public boolean shouldStopAtConstraintTypeBreakpoint(ConstraintTypeBreakpoint constraintTypeBreakpoint) {
 		return constraintTypeBreakpoint.getType() == currentConstraintType;
 	}
 	
-	/**
-	 * 
-	 * @param constraintTypeBreakpoint
-	 * @return
-	 */
 	public boolean shouldStopAtConstraintInstanceBreakpoint(ConstraintInstanceBreakpoint constraintInstanceBreakpoint) {
 		return removeRuntimeValuesFromConstraintInstance(retrieveConstraintLabel()).equals(constraintInstanceBreakpoint.getConstraintInstance());
 	}
@@ -1286,7 +1268,6 @@ public void stepReturn() throws DebugException {
 	/**
 	 * returns the current array of stackFrames, each containing variables.
 	 * NOTE: maybe we could store the stackframes that do not change
-	 * @return
 	 */
 	public synchronized IStackFrame[] getStackFrames(HenshinDebugThread debugThread) {
 		
@@ -1610,7 +1591,7 @@ public void stepReturn() throws DebugException {
 	 * 
 	 * @param expectedDebugLevel the expected {@link DebugLevel}
 	 * @param expectedVariableIndex the expected variable index (see {@link ApplicationCondition#findMatch(int)}
-	 * @param expectedConstraintType the expected constraint type (see {@link constraint#getClass()})
+	 * @param expectedConstraintType the expected constraint type (see {@link Constraint})
 	 * @param expectedConstraintIndex the expected iteration index for multiple constraints of the same type (for example: {@link Variable#attributeConstraints}).
 	 * 
 	 * @return <code>true</code> if the state is the same, <code>false</code> otherwise
@@ -1649,7 +1630,7 @@ public void stepReturn() throws DebugException {
 	
 	/**
 	 * Checks the values of the match if one was found.
-	 * @param expectedMatch The expected match
+	 * @param expectedValues the expected values
 	 * @return <code>true</code> if the values of the match are the same as the given values
 	 */
 	public boolean checkMatch(Map<Variable, EObject> expectedValues) {

--- a/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/matching/conditions/ValueBreakpoint.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/matching/conditions/ValueBreakpoint.java
@@ -6,7 +6,6 @@ public class ValueBreakpoint extends HenshinBreakpoint {
 	
 	/**
 	 * Retrieve the brekpoint's type. (type of the value we set the breakpoint for)
-	 * @return
 	 */
 	public String getType() {
 		return getAttribute("Type", "");
@@ -42,7 +41,6 @@ public class ValueBreakpoint extends HenshinBreakpoint {
 	
 	/**
 	 * Retrieve index.
-	 * @return
 	 */
 	public int getIndex() {
 		return getIntAttribute("Index", -1);

--- a/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/matching/conditions/VariableBreakpoint.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/matching/conditions/VariableBreakpoint.java
@@ -6,7 +6,6 @@ public class VariableBreakpoint extends HenshinBreakpoint {
 
 	/**
 	 * Get type name.
-	 * @return
 	 */
 	public String getTypeName() {
 		return getAttribute("TypeName", null);
@@ -28,7 +27,6 @@ public class VariableBreakpoint extends HenshinBreakpoint {
 	
 	/**
 	 * Get node path representing the variable we set a breakpoint for.
-	 * @return
 	 */
 	public String getPath() {
 		return getAttribute("Path", null);

--- a/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/matching/constraints/DomainSlot.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/matching/constraints/DomainSlot.java
@@ -20,7 +20,6 @@ import java.util.Set;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.henshin.interpreter.ApplicationMonitor;
 import org.eclipse.emf.henshin.interpreter.EGraph;
-import org.eclipse.emf.henshin.interpreter.impl.EGraphImpl;
 import org.eclipse.emf.henshin.interpreter.matching.conditions.ConditionHandler;
 import org.eclipse.emf.henshin.interpreter.monitoring.PerformanceMonitor;
 import org.eclipse.emf.henshin.interpreter.monitoring.VariableCheck;
@@ -125,7 +124,6 @@ public class DomainSlot {
 	 * Constructor.
 	 * @param conditionHandler Condition handler to be used.
 	 * @param usedObjects Used objects.
-	 * @param options Options.
 	 * @param monitor Monitor to collect performance data
 	 */
 	public DomainSlot(ConditionHandler conditionHandler, Set<EObject> usedObjects,
@@ -252,7 +250,7 @@ public class DomainSlot {
 	
 	/**
 	 * Removes the lock on this domain slot. If the domain contains additional
-	 * objects {@link #instantiate(Variable, Map, EGraphImpl)} may be called
+	 * objects {@link #instantiate(Variable, Map, EGraph)} may be called
 	 * again.
 	 * @param sender
 	 *            The variable which uses this domain slot. Only the variable

--- a/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/util/EGraphIsomorphyChecker.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/util/EGraphIsomorphyChecker.java
@@ -72,7 +72,7 @@ public class EGraphIsomorphyChecker {
 	 * Default constructor.
 	 * 
 	 * @param source Source graph.
-	 * @param useAttributes Flag indicating whether attribute values should be used.
+	 * @param ignoredAttributes Flag indicating whether attribute values should be ignored.
 	 */
 	public EGraphIsomorphyChecker(final EGraph source, List<EAttribute> ignoredAttributes) {
 		this.source = source;

--- a/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/util/PartialMatchReport.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/util/PartialMatchReport.java
@@ -34,9 +34,6 @@ public class PartialMatchReport {
 	 */
 	Map<Rule, List<PartialMatchInfo>> infos = new HashMap<Rule, List<PartialMatchInfo>>();
 
-	/**
-	 * @return
-	 */
 	public Map<Rule, List<PartialMatchInfo>> getInfos() {
 		return infos;
 	}
@@ -50,9 +47,6 @@ public class PartialMatchReport {
 		this.matches = matches;
 	}
 
-	/**
-	 * @return
-	 */
 	public Module getModule() {
 		return module;
 	}
@@ -179,7 +173,6 @@ public class PartialMatchReport {
 	 * 
 	 * @param originalRule Rule to collect infos about partial matches for.
 	 * @param matches Module to be used.
-	 * @return 
 	 */
 	public void collectPartialMatchInfos(
 			Rule originalRule, List<Match> matches) {

--- a/plugins/org.eclipse.emf.henshin.model/src/org/eclipse/emf/henshin/model/MappingList.java
+++ b/plugins/org.eclipse.emf.henshin.model/src/org/eclipse/emf/henshin/model/MappingList.java
@@ -146,8 +146,8 @@ public interface MappingList extends EList<Mapping> {
 
 	/**
 	 * Get the image of an untyped object in a target graph. 
-	 * This delegates to {@link #getImage(Node)}, {@link #getImage(Edge)} 
-	 * or {@link #getImage(Attribute)}. It throws an 
+	 * This delegates to {@link #getImage(Node, Graph)}, {@link #getImage(Edge, Graph)} 
+	 * or {@link #getImage(Attribute, Graph)}. It throws an 
 	 * {@link IllegalArgumentException} if the type of the object is unknown.
 	 * @param origin Origin.
 	 * @param imageGraph Image graph.

--- a/plugins/org.eclipse.emf.henshin.model/src/org/eclipse/emf/henshin/model/compact/CModule.java
+++ b/plugins/org.eclipse.emf.henshin.model/src/org/eclipse/emf/henshin/model/compact/CModule.java
@@ -19,7 +19,7 @@ import org.eclipse.emf.henshin.model.resource.HenshinResourceSet;
 
 /**
  * Compact Module.
- * Contains a {@link org.eclipse.emf.henshin.model.Module]-Instance 
+ * Contains a {@link Module}-Instance 
  * Provides compact Methods to perform basic-operations on said Instance.
  * @author Johannes Ludwig
  */
@@ -48,7 +48,7 @@ public class CModule {
 	//Static Methods
 	/**
 	 * Loads a CModule from a *.henshin File
-	 * @param filepath relative Filepath from working directory.
+	 * @param filePath relative file path from working directory.
 	 * @return the loaded CModule
 	 */
 	public static CModule loadFromFile(String filePath) {
@@ -76,7 +76,7 @@ public class CModule {
 	/**
 	 * Adds an EPackage from an *.ecore-file to the Imports of the Module-Instance.
 	 * registers the given Package in the local PackageRegistry.
-	 * @param fileName The filename of the *.ecore-File
+	 * @param filePath The filename of the *.ecore-File
 	 */
 	public CModule addImportsFromFile(String filePath) {
 		//Split the fileName into File-Path and File-Name
@@ -94,7 +94,7 @@ public class CModule {
 	
 	/**
 	 * Saves the Module-Instance at the given path in *.henshin format
-	 * @param filename relative path coming from the ResourcePath of the Module
+	 * @param fileName relative path coming from the ResourcePath of the Module
 	 */
 	public void save(String fileName) {
 		String[] path = fileName.split("/");

--- a/plugins/org.eclipse.emf.henshin.model/src/org/eclipse/emf/henshin/model/compact/CRule.java
+++ b/plugins/org.eclipse.emf.henshin.model/src/org/eclipse/emf/henshin/model/compact/CRule.java
@@ -17,7 +17,7 @@ import org.eclipse.emf.henshin.model.Unit;
 
 /**
  * Compact Rule
- * Contains a {@link import org.eclipse.emf.henshin.model.Rule;}-Instance
+ * Contains a {@link Rule}-Instance
  * Provides compact Methods to create Rule-Components
  * @author Johannes Ludwig
  */

--- a/plugins/org.eclipse.emf.henshin.model/src/org/eclipse/emf/henshin/model/resource/HenshinResourceSet.java
+++ b/plugins/org.eclipse.emf.henshin.model/src/org/eclipse/emf/henshin/model/resource/HenshinResourceSet.java
@@ -120,7 +120,7 @@ public class HenshinResourceSet extends ResourceSetImpl {
 	 * resource factories are registered only if no other resource factory
 	 * is already registered for the file extension.
 	 * 
-	 * @param fileExtension File extensions.
+	 * @param fileExtensions File extensions.
 	 */
 	public void registerXMIResourceFactories(String... fileExtensions) {
 		Map<String, Object> map = getResourceFactoryRegistry().getExtensionToFactoryMap();
@@ -252,7 +252,7 @@ public class HenshinResourceSet extends ResourceSetImpl {
 	 * instance models to be transformed, and then call this method.
 	 * </p>
 	 * 
-	 * @param path Possible relative path and file name of a Henshin resource.
+	 * @param uri Possible relative path and file name of a Henshin resource.
 	 * @param fixImports If <code>true</code>, tries to fix the imports of the loaded module (default is <code>false</code>).
 	 * @return The contained {@link Module}.
 	 */

--- a/plugins/org.eclipse.emf.henshin.model/src/org/eclipse/emf/henshin/model/staticanalysis/NodeEquivalence.java
+++ b/plugins/org.eclipse.emf.henshin.model/src/org/eclipse/emf/henshin/model/staticanalysis/NodeEquivalence.java
@@ -23,7 +23,7 @@ public class NodeEquivalence extends ArrayList<Node> {
 	/**
 	 * Compute the require node equivalences for a given rule.
 	 * Every node equivalence has at least two nodes.
-	 * @param rule The rule.
+	 * @param graph The graph.
 	 * @return The list of require node equivalences.
 	 */
 	public static List<NodeEquivalence> computeEquivalences(Graph graph) {

--- a/plugins/org.eclipse.emf.henshin.model/src/org/eclipse/emf/henshin/model/util/HenshinModelCleaner.java
+++ b/plugins/org.eclipse.emf.henshin.model/src/org/eclipse/emf/henshin/model/util/HenshinModelCleaner.java
@@ -396,7 +396,6 @@ public class HenshinModelCleaner {
 	/**
 	 * Clean a mapping list. Removes invalid mappings.
 	 * @param mappings Mapping list to be cleaned.
-	 * @param signatures Signatures of the functions that the mapping list stands for.
 	 */
 	public static void cleanMappingList(MappingList mappings, Graph... graphs) {
 		

--- a/plugins/org.eclipse.emf.henshin.model/src/org/eclipse/emf/henshin/model/util/RuleGeneralizer.java
+++ b/plugins/org.eclipse.emf.henshin.model/src/org/eclipse/emf/henshin/model/util/RuleGeneralizer.java
@@ -23,7 +23,7 @@ public class RuleGeneralizer {
 	/**
 	 * Makes each << preserve >> and << delete >> node as abstract as possible.
 	 * 
-	 * @param module The rule to be generalized.
+	 * @param rule The rule to be generalized.
 	 */
 	public static void generalizeRule(Rule rule) {
 

--- a/plugins/org.eclipse.emf.henshin.model/src/org/eclipse/emf/henshin/model/util/RuleMinimizer.java
+++ b/plugins/org.eclipse.emf.henshin.model/src/org/eclipse/emf/henshin/model/util/RuleMinimizer.java
@@ -22,7 +22,7 @@ public class RuleMinimizer {
 	/**
 	 * Removes all non-context (preserve) nodes from a rule.
 	 * 
-	 * @param module The Henshin Module.
+	 * @param rule The Henshin Module.
 	 */
 	public static void reduceToMinimalRule(Rule rule) {
 

--- a/plugins/org.eclipse.emf.henshin.model/src/org/eclipse/emf/henshin/model/util/ScriptEngineWrapper.java
+++ b/plugins/org.eclipse.emf.henshin.model/src/org/eclipse/emf/henshin/model/util/ScriptEngineWrapper.java
@@ -101,7 +101,7 @@ public class ScriptEngineWrapper {
 
 	/**
 	 * A wrapper for the put operation of the wrapped script engine.
-	 * @see javax.script.ScriptEngine.put(String key, Object value)
+	 * @see javax.script.ScriptEngine#put(String, Object)
 	 * 
 	 * @param key The name of named value to add
 	 * @param value The value of named value to add

--- a/plugins/org.eclipse.emf.henshin.multicda.cda/src/org/eclipse/emf/henshin/multicda/cda/Pushout.java
+++ b/plugins/org.eclipse.emf.henshin.multicda.cda/src/org/eclipse/emf/henshin/multicda/cda/Pushout.java
@@ -71,9 +71,6 @@ public class Pushout {
 	/**
 	 * Creates Pushout of rule1.Lhs() <-- S --> rule2.Lhs() and rule1.Lhs() --> G <-- rule2.Lhs()
 	 * 
-	 * @param rule1
-	 * @param s1span
-	 * @param rule2
 	 * @param validate turns the pushout validation on or of
 	 */
 

--- a/plugins/org.eclipse.emf.henshin.multicda.cda/src/org/eclipse/emf/henshin/multicda/cda/Utils.java
+++ b/plugins/org.eclipse.emf.henshin.multicda.cda/src/org/eclipse/emf/henshin/multicda/cda/Utils.java
@@ -452,10 +452,6 @@ public abstract class Utils {
 		return result;
 	}
 
-	/**
-	 * @param graph
-	 * @return
-	 */
 	public static EPackage graphToEPackage(Graph g) {
 		Set<String> added = new HashSet<String>();
 		EPackage result = EcoreFactory.eINSTANCE.createEPackage();

--- a/plugins/org.eclipse.emf.henshin.multicda.cda/src/org/eclipse/emf/henshin/multicda/cda/computation/DeleteUseConflictReasonComputation.java
+++ b/plugins/org.eclipse.emf.henshin.multicda.cda/src/org/eclipse/emf/henshin/multicda/cda/computation/DeleteUseConflictReasonComputation.java
@@ -46,10 +46,6 @@ public class DeleteUseConflictReasonComputation<T extends Reason> {
 
 	/**
 	 * constructor
-	 * 
-	 * @param rule1
-	 * @param rule2
-	 * @param conflictReasonsFromR22
 	 */
 	public DeleteUseConflictReasonComputation(Rule rule1, Rule rule2, Set<T> normalCR, Set<T> DUCRs) {
 		this.rule1 = rule1;
@@ -60,9 +56,6 @@ public class DeleteUseConflictReasonComputation<T extends Reason> {
 
 	/**
 	 * constructs all Initial Reasons as candidates for r1 and r2
-	 * 
-	 * @param conflictReasons
-	 * @return result
 	 */
 	public Set<T> computeDeleteUseConflictReason() {
 		Set<T> result = new HashSet<>();
@@ -202,7 +195,7 @@ public class DeleteUseConflictReasonComputation<T extends Reason> {
 		return G1toG2;
 	}
 
-	private static final String INTERSECTIONSEPERATOR = "_§_";
+	private static final String INTERSECTIONSEPERATOR = "_ï¿½_";
 
 	/**
 	 * @param r2
@@ -244,7 +237,7 @@ public class DeleteUseConflictReasonComputation<T extends Reason> {
 		Reason uniqueSpan = null;
 		Graph pushoutGraph = pushout.getResultGraph();
 		// if (precondition(sap, sp1, sp2)) //TODO: Nachfragen ob die Precondition so
-		// richtig ist: sie schmeißt meiner meinung nach immer false
+		// richtig ist: sie schmeiï¿½t meiner meinung nach immer false
 		// return null;
 		Set<Mapping> mappingsInL1 = computeMappingStoL(pushout, rule1, sap, sp1, sp2);
 		Set<Mapping> mappingsInL2 = computeMappingStoL(pushout, rule2, sap, sp2, sp1);

--- a/plugins/org.eclipse.emf.henshin.multicda.cda/src/org/eclipse/emf/henshin/multicda/cda/computation/MinimalReasonComputation.java
+++ b/plugins/org.eclipse.emf.henshin.multicda.cda/src/org/eclipse/emf/henshin/multicda/cda/computation/MinimalReasonComputation.java
@@ -108,12 +108,6 @@ public class MinimalReasonComputation {
 
 	/**
 	 * 
-	 * @param rule1
-	 * @param rule2
-	 * @param poDangling
-	 * @param s1
-	 * @param mappingOfRule1InOverlapG
-	 * @param mappingOfRule2InOverlapG
 	 * @return A set of fixing edges, that is, edges in R1 suitable to act as a
 	 *         counterpart for the dangling edge originating from R2.
 	 */

--- a/plugins/org.eclipse.emf.henshin.multicda.cda/src/org/eclipse/emf/henshin/multicda/cda/framework/CdaWorker.java
+++ b/plugins/org.eclipse.emf.henshin.multicda.cda/src/org/eclipse/emf/henshin/multicda/cda/framework/CdaWorker.java
@@ -195,17 +195,11 @@ public class CdaWorker extends Worker {
 		return minimalReasons;
 	}
 
-	/**
-	 * @return
-	 */
 	@Override
 	public Set<Reason> getResult() {
 		return reasons;
 	}
 
-	/**
-	 * @return
-	 */
 	public Set<Atom> getAtoms() {
 		return atoms;
 	}
@@ -400,7 +394,7 @@ public class CdaWorker extends Worker {
 	 * 
 	 * @param cps
 	 *            to compare
-	 * @param asserts
+	 * @param assertsPrint
 	 *            true if an assertion should be done by failed comparison
 	 * @return Map of matched critical Pairs and Reasons
 	 */

--- a/plugins/org.eclipse.emf.henshin.multicda.cda/src/org/eclipse/emf/henshin/multicda/cda/framework/Options.java
+++ b/plugins/org.eclipse.emf.henshin.multicda.cda/src/org/eclipse/emf/henshin/multicda/cda/framework/Options.java
@@ -75,7 +75,7 @@ public class Options {
 	/**
 	 * Default is printHeader, printResults, printWhenResult and silent on.
 	 * 
-	 * @param options
+	 * @param flags
 	 *            1:dependency, 2:essential, 3:initial, 4:prepare
 	 *            5:noneDeletionSecondRule, 6:printHeader, 7:printResults, 8:silent,
 	 *            9:print when result found, 10:print whole s2 Set

--- a/plugins/org.eclipse.emf.henshin.multicda.cda/src/org/eclipse/emf/henshin/multicda/cda/framework/Worker.java
+++ b/plugins/org.eclipse.emf.henshin.multicda.cda/src/org/eclipse/emf/henshin/multicda/cda/framework/Worker.java
@@ -29,7 +29,6 @@ public abstract class Worker {
 	 * @param errorOut
 	 *            first bool for error showing, second for System print. Default
 	 *            values are false, true.
-	 * @return
 	 */
 	public String print(String message, boolean... errorOut) {
 		message = NAME + ": " + message;

--- a/plugins/org.eclipse.emf.henshin.multicda.cpa/src/org/eclipse/emf/henshin/multicda/cpa/persist/SpanNode.java
+++ b/plugins/org.eclipse.emf.henshin.multicda.cpa/src/org/eclipse/emf/henshin/multicda/cpa/persist/SpanNode.java
@@ -49,7 +49,6 @@ public class SpanNode extends TreeFolder {
 	 * 
 	 * @param firstRuleURI The <code>URI</code> of the first rule.
 	 * @param secondRuleURI The <code>URI</code> of the second rule.
-	 * @param nodeURI
 	 */
 	public SpanNode(String numberedNameOfCPKind, URI firstRuleURI, URI secondRuleURI, URI minimalModelURI, boolean conflict) {
 		this(numberedNameOfCPKind, firstRuleURI, secondRuleURI, minimalModelURI, null, conflict);

--- a/plugins/org.eclipse.emf.henshin.rulegen/src/org/eclipse/emf/henshin/rulegen/matching/IMatcher.java
+++ b/plugins/org.eclipse.emf.henshin.rulegen/src/org/eclipse/emf/henshin/rulegen/matching/IMatcher.java
@@ -11,19 +11,11 @@ public interface IMatcher {
 	
 	/**
 	 * Creates a matching, i.e., determines corresponding elements in modelA and modelB.
-	 * 
-	 * @param modelA
-	 * @param modelB
-	 * @return
 	 */
 	public Matching createMatching(Resource modelA, Resource modelB);
 	
 	/**
 	 * Returns whether the matcher can handle the given models.
-	 * 
-	 * @param modelA
-	 * @param modelB
-	 * @return
 	 */
 	public boolean canHandle(Resource modelA, Resource modelB);
 }

--- a/plugins/org.eclipse.emf.henshin.rulegen/src/org/eclipse/emf/henshin/rulegen/matching/Matching.java
+++ b/plugins/org.eclipse.emf.henshin.rulegen/src/org/eclipse/emf/henshin/rulegen/matching/Matching.java
@@ -29,9 +29,6 @@ public class Matching {
 
 	/**
 	 * Constructor.
-	 * 
-	 * @param modelA
-	 * @param modelB
 	 */
 	public Matching() {
 		super();

--- a/plugins/org.eclipse.emf.henshin.rulegen/src/org/eclipse/emf/henshin/rulegen/simple/ExampleBasedRuleGenerator.java
+++ b/plugins/org.eclipse.emf.henshin.rulegen/src/org/eclipse/emf/henshin/rulegen/simple/ExampleBasedRuleGenerator.java
@@ -45,10 +45,6 @@ public class ExampleBasedRuleGenerator {
 
 	/**
 	 * Constructs a Henshin rule from a pair of models (original model and changed model).
-	 * 
-	 * @param ruleName
-	 * @param pathA
-	 * @param pathB
 	 */
 	public Rule generateRule(String ruleName, Resource modelA, Resource modelB) {
 		// Init

--- a/plugins/org.eclipse.emf.henshin.statespace.explorer/src/org/eclipse/emf/henshin/statespace/explorer/commands/CreateInitialStateCommand.java
+++ b/plugins/org.eclipse.emf.henshin.statespace.explorer/src/org/eclipse/emf/henshin/statespace/explorer/commands/CreateInitialStateCommand.java
@@ -31,8 +31,6 @@ public class CreateInitialStateCommand extends AbstractStateSpaceCommand {
 	
 	/**
 	 * Default constructor.
-	 * @param state State to be added.
-	 * @param stateSpace State space.
 	 */
 	public CreateInitialStateCommand(Model model, StateSpaceManager manager) {
 		super("create initial state", manager);

--- a/plugins/org.eclipse.emf.henshin.statespace.explorer/src/org/eclipse/emf/henshin/statespace/explorer/commands/DeleteStateCommand.java
+++ b/plugins/org.eclipse.emf.henshin.statespace.explorer/src/org/eclipse/emf/henshin/statespace/explorer/commands/DeleteStateCommand.java
@@ -25,7 +25,7 @@ public class DeleteStateCommand extends AbstractStateSpaceCommand {
 	/**
 	 * Default constructor.
 	 * @param state State to be deleted.
-	 * @param stateSpace State space.
+	 * @param manager State space manager.
 	 */
 	public DeleteStateCommand(State state, StateSpaceManager manager) {
 		super("deleting state", manager);

--- a/plugins/org.eclipse.emf.henshin.statespace.explorer/src/org/eclipse/emf/henshin/statespace/explorer/commands/ExploreStatesCommand.java
+++ b/plugins/org.eclipse.emf.henshin.statespace.explorer/src/org/eclipse/emf/henshin/statespace/explorer/commands/ExploreStatesCommand.java
@@ -37,7 +37,6 @@ public class ExploreStatesCommand extends AbstractStateSpaceCommand {
 	/**
 	 * Constructor.
 	 * @param helper State space exploration helper.
-	 * @param generateLocations Whether to generate locations.
 	 */
 	public ExploreStatesCommand(StateSpaceExplorationHelper helper) {
 		super("explore states", helper.getStateSpaceManager());

--- a/plugins/org.eclipse.emf.henshin.statespace.explorer/src/org/eclipse/emf/henshin/statespace/explorer/jobs/LayoutStateSpaceJob.java
+++ b/plugins/org.eclipse.emf.henshin.statespace.explorer/src/org/eclipse/emf/henshin/statespace/explorer/jobs/LayoutStateSpaceJob.java
@@ -33,7 +33,6 @@ public class LayoutStateSpaceJob extends Job {
 	/**
 	 * Default constructor.
 	 * @param stateSpace State space.
-	 * @param display Display.
 	 */
 	public LayoutStateSpaceJob(StateSpace stateSpace) {
 		super("Layouting state space");

--- a/plugins/org.eclipse.emf.henshin.statespace.explorer/src/org/eclipse/emf/henshin/statespace/explorer/jobs/ValidateStateSpaceJob.java
+++ b/plugins/org.eclipse.emf.henshin.statespace.explorer/src/org/eclipse/emf/henshin/statespace/explorer/jobs/ValidateStateSpaceJob.java
@@ -34,7 +34,6 @@ public class ValidateStateSpaceJob extends AbstractStateSpaceJob {
 	
 	/**
 	 * Default constructor.
-	 * @param validator State space validator.
 	 * @param manager State space manager.
 	 */
 	public ValidateStateSpaceJob(StateSpaceManager manager) {

--- a/plugins/org.eclipse.emf.henshin.statespace.explorer/src/org/eclipse/emf/henshin/statespace/explorer/parts/StateSpaceToolsMenu.java
+++ b/plugins/org.eclipse.emf.henshin.statespace.explorer/src/org/eclipse/emf/henshin/statespace/explorer/parts/StateSpaceToolsMenu.java
@@ -325,7 +325,7 @@ public class StateSpaceToolsMenu extends Composite {
 	
 	/**
 	 * Set the job manager to be used.
-	 * @param manager Job manager.
+	 * @param jobManager Job manager.
 	 */
 	public void setJobManager(StateSpaceJobManager jobManager) {
 		if (this.jobManager!=null) removeListeners();

--- a/plugins/org.eclipse.emf.henshin.statespace.external/src/org/eclipse/emf/henshin/statespace/external/AbstractFileBasedValidator.java
+++ b/plugins/org.eclipse.emf.henshin.statespace.external/src/org/eclipse/emf/henshin/statespace/external/AbstractFileBasedValidator.java
@@ -116,7 +116,6 @@ public abstract class AbstractFileBasedValidator extends AbstractStateSpaceValid
 	/**
 	 * Export a state space as an AUT file.
 	 * @param stateSpace State space.
-	 * @param aut The AUT file.
 	 * @throws IOException On I/O errors.
 	 */
 	protected File exportAsAUT(StateSpace stateSpace, IProgressMonitor monitor) throws IOException {

--- a/plugins/org.eclipse.emf.henshin.statespace/src/org/eclipse/emf/henshin/statespace/EqualityHelper.java
+++ b/plugins/org.eclipse.emf.henshin.statespace/src/org/eclipse/emf/henshin/statespace/EqualityHelper.java
@@ -25,7 +25,6 @@ public interface EqualityHelper extends EObject {
 	/**
 	 * Returns the value of the '<em><b>Check Link Order</b></em>' attribute.
 	 * @return the value of the '<em>Check Link Order</em>' attribute.
-	 * @see #setCheckLinkOrder(boolean)
 	 * @see org.eclipse.emf.henshin.statespace.StateSpacePackage#getEqualityHelper_CheckLinkOrder()
 	 * @model
 	 * @generated

--- a/plugins/org.eclipse.emf.henshin.statespace/src/org/eclipse/emf/henshin/statespace/Model.java
+++ b/plugins/org.eclipse.emf.henshin.statespace/src/org/eclipse/emf/henshin/statespace/Model.java
@@ -32,7 +32,6 @@ public interface Model extends EObject {
 	/**
 	 * Get the resource that contains the actual model elements.
 	 * @return the value of the '<em>Resource</em>' attribute.
-	 * @see #setResource(Resource)
 	 * @see org.eclipse.emf.henshin.statespace.StateSpacePackage#getModel_Resource()
 	 * @model transient="true"
 	 * @generated
@@ -42,7 +41,7 @@ public interface Model extends EObject {
 	/**
 	 * Get the associated {@link EGraph} instance for this model.
 	 * @return the value of the '<em>EGraph</em>' attribute.
-	 * @see org.eclipse.emf.henshin.statespace.StateSpacePackage#getModel_EmfGraph()
+	 * @see org.eclipse.emf.henshin.statespace.StateSpacePackage#getModel_EGraph()
 	 * @model dataType="org.eclipse.emf.henshin.statespace.EmfGraph" transient="true" changeable="false"
 	 * @generated
 	 */
@@ -77,7 +76,7 @@ public interface Model extends EObject {
 	/**
 	 * Set the object keys of this state model as an integer array.
 	 * This forwards to {@link #getObjectKeysMap()}.
-	 * @param objectKeys the new value of the '<em>Object Keys</em>' attribute.
+	 * @param value the new value of the '<em>Object Keys</em>' attribute.
 	 * @see #getObjectKeys()
 	 * @generated
 	 */
@@ -85,7 +84,7 @@ public interface Model extends EObject {
 
 	/**
 	 * Get the number of objects in this model.
-	 * This is derived from {@link #getEmfGraph()}.
+	 * This is derived from {@link #getEGraph()}.
 	 * @return the value of the '<em>Object Count</em>' attribute.
 	 * @see org.eclipse.emf.henshin.statespace.StateSpacePackage#getModel_ObjectCount()
 	 * @model transient="true" changeable="false" volatile="true" derived="true"
@@ -95,7 +94,7 @@ public interface Model extends EObject {
 
 	/**
 	 * Get a copy of this model.
-	 * @param Optional match.
+	 * @param match optional match
 	 * @model matchDataType="org.eclipse.emf.henshin.statespace.Match"
 	 * @generated
 	 */
@@ -110,7 +109,7 @@ public interface Model extends EObject {
 	boolean updateObjectKeys(EList<EClass> identityTypes);
 
 	/**
-	 * Collect missing root objects from the {@link EGraphImpl} of this model.
+	 * Collect missing root objects from the {@link EGraph} of this model.
 	 * New root objects will be added to this objects resource.
 	 * @model
 	 * @generated

--- a/plugins/org.eclipse.emf.henshin.statespace/src/org/eclipse/emf/henshin/statespace/State.java
+++ b/plugins/org.eclipse.emf.henshin.statespace/src/org/eclipse/emf/henshin/statespace/State.java
@@ -11,7 +11,6 @@ package org.eclipse.emf.henshin.statespace;
 
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.henshin.model.Rule;
-import org.eclipse.emf.ecore.resource.Resource;
 
 /**
  * Interface for states.
@@ -106,7 +105,7 @@ public interface State extends Storage {
 	/**
 	 * Get the associated model of this state.
 	 * @return the associated model.
-	 * @see #setModel(Resource)
+	 * @see #setModel(Model)
 	 * @model transient="true"
 	 * @generated
 	 */
@@ -131,7 +130,7 @@ public interface State extends Storage {
 
 	/**
 	 * Set the state space that contains this state.
-	 * @param stateSpace the container state space.
+	 * @param value the container state space.
 	 * @see #getStateSpace()
 	 * @generated
 	 */
@@ -149,7 +148,7 @@ public interface State extends Storage {
 
 	/**
 	 * Sets the location of this state. The argument must have length 3.
-	 * @param the new location of the state.
+	 * @param location the new location of the state.
 	 * @see #getLocation()
 	 * @generated NOT
 	 */
@@ -229,7 +228,7 @@ public interface State extends Storage {
 
 	/**
 	 * Set the hash code of this state.
-	 * @param hashCode the hash code.
+	 * @param value the hash code.
 	 * @see #getHashCode()
 	 * @generated
 	 */
@@ -239,7 +238,7 @@ public interface State extends Storage {
 	 * Get the number of nodes in this state's model.
 	 * @return the value of the '<em>Node Count</em>' attribute.
 	 * @see #setObjectCount(int)
-	 * @see org.eclipse.emf.henshin.statespace.StateSpacePackage#getState_NodeCount()
+	 * @see org.eclipse.emf.henshin.statespace.StateSpacePackage#getState_ObjectCount()
 	 * @model transient="true" volatile="true"
 	 * @generated
 	 */
@@ -247,7 +246,7 @@ public interface State extends Storage {
 
 	/**
 	 * Set the number of objects in this state's model.
-	 * @param objectCount the new value of the '<em>Object Count</em>' attribute.
+	 * @param value the new value of the '<em>Object Count</em>' attribute.
 	 * @see #getObjectCount()
 	 * @generated
 	 */
@@ -263,7 +262,7 @@ public interface State extends Storage {
 
 	/**
 	 * Set the object keys for the current state model.
-	 * @param objectKeys the new value of the '<em>Object Keys</em>' attribute.
+	 * @param value the new value of the '<em>Object Keys</em>' attribute.
 	 * @see #getObjectKeys()
 	 * @generated
 	 */

--- a/plugins/org.eclipse.emf.henshin.statespace/src/org/eclipse/emf/henshin/statespace/StateSpace.java
+++ b/plugins/org.eclipse.emf.henshin.statespace/src/org/eclipse/emf/henshin/statespace/StateSpace.java
@@ -223,7 +223,7 @@ public interface StateSpace extends Storage {
 	 * Check whether labels should be hidden.
 	 * @return the value of the '<em>Hide Labels</em>' attribute.
 	 * @see #setLayoutHideLabels(boolean)
-	 * @see org.eclipse.emf.henshin.statespace.StateSpacePackage#getStateSpace_HideLabels()
+	 * @see org.eclipse.emf.henshin.statespace.StateSpacePackage#getStateSpace_LayoutHideLabels()
 	 * @model transient="true" volatile="true"
 	 * @generated
 	 */

--- a/plugins/org.eclipse.emf.henshin.statespace/src/org/eclipse/emf/henshin/statespace/StateSpaceExporter.java
+++ b/plugins/org.eclipse.emf.henshin.statespace/src/org/eclipse/emf/henshin/statespace/StateSpaceExporter.java
@@ -27,7 +27,7 @@ public interface StateSpaceExporter {
 	 * @param uri URI where the state space should be exported to.
 	 * @param monitor Progress monitor.
 	 * @throws StateSpaceException On state space errors. 
-	 * @throws Exception On I/O errors.
+	 * @throws IOException On I/O errors.
 	 */
 	void doExport(StateSpace stateSpace, URI uri, String parameters, IProgressMonitor monitor) throws IOException, StateSpaceException;
 	

--- a/plugins/org.eclipse.emf.henshin.statespace/src/org/eclipse/emf/henshin/statespace/StateSpaceManager.java
+++ b/plugins/org.eclipse.emf.henshin.statespace/src/org/eclipse/emf/henshin/statespace/StateSpaceManager.java
@@ -57,8 +57,8 @@ public interface StateSpaceManager extends StateSpaceIndex {
 	 * Explore a state. This computes all outgoing transitions
 	 * and their target states and adds them to the state space
 	 * if they do not exist yet.
-	 * @param state State to be explored.
-	 * @param generateLocation Whether to generate a location for the new states.
+	 * @param states States to be explored.
+	 * @param generateLocations Whether to generate locations for the new states.
 	 * @return List of newly created successor states.
 	 * @exception StateSpaceException If the state space contains errors.
 	 */
@@ -76,7 +76,7 @@ public interface StateSpaceManager extends StateSpaceIndex {
 	/**
 	 * Reset the state space managed by this instance.
 	 * This removes all derived states and all transitions.
-	 * @param remobeInitial Determines whether also initial states should be removed.
+	 * @param removeInitial Determines whether also initial states should be removed.
 	 * @throws StateSpaceException On errors.
 	 */
 	void resetStateSpace(boolean removeInitial) throws StateSpaceException;

--- a/plugins/org.eclipse.emf.henshin.statespace/src/org/eclipse/emf/henshin/statespace/Transition.java
+++ b/plugins/org.eclipse.emf.henshin.statespace/src/org/eclipse/emf/henshin/statespace/Transition.java
@@ -59,7 +59,7 @@ public interface Transition extends Storage {
 	/**
 	 * Returns the value of the '<em><b>Rule</b></em>' attribute.
 	 * @return the value of the '<em>Rule</em>' attribute.
-	 * @see #setRule(String)
+	 * @see #setRule(Rule)
 	 * @model
 	 * @generated
 	 */

--- a/plugins/org.eclipse.emf.henshin.statespace/src/org/eclipse/emf/henshin/statespace/hashcodes/StateSpaceHashCodeUtil.java
+++ b/plugins/org.eclipse.emf.henshin.statespace/src/org/eclipse/emf/henshin/statespace/hashcodes/StateSpaceHashCodeUtil.java
@@ -25,8 +25,7 @@ import org.eclipse.emf.henshin.statespace.StateSpace;
 public class StateSpaceHashCodeUtil {
 	
 	/**
-	 * Compute the hash code of a model. This also updates the object hash codes
-	 * as also provides by {@link #updateObjectHashCodes(Model, EqualityHelper)}.
+	 * Compute the hash code of a model. This also updates the object hash codes.
 	 * @param model The model.
 	 * @return The model's hash code.
 	 */

--- a/plugins/org.eclipse.emf.henshin.statespace/src/org/eclipse/emf/henshin/statespace/impl/ModelImpl.java
+++ b/plugins/org.eclipse.emf.henshin.statespace/src/org/eclipse/emf/henshin/statespace/impl/ModelImpl.java
@@ -52,7 +52,7 @@ public class ModelImpl extends MinimalEObjectImpl.Container implements Model {
 	/**
 	 * Constructor.
 	 * @param resource Resource for this model.
-	 * @param emfGraph EmfGraph for this model.
+	 * @param eGraph EmfGraph for this model.
 	 * @generated NOT
 	 */
 	public ModelImpl(Resource resource, EGraph eGraph) {

--- a/plugins/org.eclipse.emf.henshin.statespace/src/org/eclipse/emf/henshin/statespace/impl/StateExplorer.java
+++ b/plugins/org.eclipse.emf.henshin.statespace/src/org/eclipse/emf/henshin/statespace/impl/StateExplorer.java
@@ -39,6 +39,7 @@ import org.eclipse.emf.henshin.statespace.StateSpace;
 import org.eclipse.emf.henshin.statespace.StateSpaceException;
 import org.eclipse.emf.henshin.statespace.StateSpaceFactory;
 import org.eclipse.emf.henshin.statespace.StateSpaceIndex;
+import org.eclipse.emf.henshin.statespace.StateSpaceManager;
 import org.eclipse.emf.henshin.statespace.StateSpacePlugin;
 import org.eclipse.emf.henshin.statespace.StateValidator;
 import org.eclipse.emf.henshin.statespace.Transition;
@@ -362,7 +363,7 @@ public class StateExplorer {
 
 	/**
 	 * Derive a model.
-	 * @param State state.
+	 * @param state state.
 	 * @param fromInitial Whether to derive it from an initial state.
 	 * @return The derived model.
 	 * @throws StateSpaceException On errors.
@@ -532,7 +533,7 @@ public class StateExplorer {
 
 		/**
 		 * Constructor.
-		 * @param statepace State space.
+		 * @param stateSpace State space.
 		 */
 		public ModelPostProcessor(StateSpace stateSpace) {
 			ScriptEngineManager manager = new ScriptEngineManager();

--- a/plugins/org.eclipse.emf.henshin.tests/src/org/eclipse/emf/henshin/tests/cpa/DanglingOptionTest.java
+++ b/plugins/org.eclipse.emf.henshin.tests/src/org/eclipse/emf/henshin/tests/cpa/DanglingOptionTest.java
@@ -127,8 +127,6 @@ public class DanglingOptionTest {
 
 	/**
 	 * Test for the 'check'-function of the passed rule set. Check function shall deny the inconsistent rule set.
-	 * 
-	 * @throws UnsupportedRuleException when attempting to analyze rules which are not supported
 	 */
 	@Test
 	public void checkDanglingIconsistent() {

--- a/plugins/org.eclipse.emf.henshin.tests/src/org/eclipse/emf/henshin/tests/cpa/InjectiveMatchingOptionTest.java
+++ b/plugins/org.eclipse.emf.henshin.tests/src/org/eclipse/emf/henshin/tests/cpa/InjectiveMatchingOptionTest.java
@@ -49,8 +49,6 @@ public class InjectiveMatchingOptionTest {
 	/**
 	 * Test for the 'check'-function of the passed rule set. Check function shall deny the inconsistent rule set
 	 * regarding the injective matching property.
-	 * 
-	 * @throws UnsupportedRuleException when attempting to analyze rules which are not supported
 	 */
 	@Test
 	public void checkInjectiveMatchingInconsistent() {

--- a/plugins/org.eclipse.emf.henshin.tests/src/org/eclipse/emf/henshin/tests/framework/ElementGroups.java
+++ b/plugins/org.eclipse.emf.henshin.tests/src/org/eclipse/emf/henshin/tests/framework/ElementGroups.java
@@ -28,10 +28,10 @@ public class ElementGroups {
 	 * Asserts that the specified element group is deleted from the graph.<br>
 	 * This is the case if one or more elements in the group have been deleted from the graph.<br>
 	 * To assert that <b>all</b> elements contained in the group have been deleted, use
-	 * {@link assertAllElementsFromElementGroupDeleted}
+	 * {@link #assertAllElementsFromElementGroupDeleted}
 	 * 
 	 * @param group {@link Collection} of {@link EObject}s containing the elements to check
-	 * @param graph {@link EGraphImpl}
+	 * @param graph {@link EGraph}
 	 * @throws AssertionError
 	 */
 	public static void assertElementGroupDeleted(Collection<? extends EObject> group, EGraph graph)
@@ -44,10 +44,10 @@ public class ElementGroups {
 
 	/**
 	 * Asserts that all elements from the specified group are deleted from the graph. To assert that at least one
-	 * element is deleted, use {@link assertElementGroupDeleted}
+	 * element is deleted, use {@link #assertElementGroupDeleted}
 	 * 
 	 * @param group {@link Collection} of {@link EObject}s containing the elements to check
-	 * @param graph {@link EGraphImpl}
+	 * @param graph {@link EGraph}
 	 * @throws AssertionError
 	 */
 	public static void assertAllElementsFromElementGroupDeleted(Collection<? extends EObject> group, EGraph graph)
@@ -66,7 +66,7 @@ public class ElementGroups {
 	 * from the group)
 	 * 
 	 * @param group {@link Collection} of {@link EObject}s containing the elements to check
-	 * @param graph {@link EGraphImpl}
+	 * @param graph {@link EGraph}
 	 * @throws AssertionError
 	 */
 	public static void assertNoElementFromElementGroupDeleted(Collection<? extends EObject> group, EGraph graph)

--- a/plugins/org.eclipse.emf.henshin.tests/src/org/eclipse/emf/henshin/tests/framework/Graphs.java
+++ b/plugins/org.eclipse.emf.henshin.tests/src/org/eclipse/emf/henshin/tests/framework/Graphs.java
@@ -28,7 +28,7 @@ public class Graphs {
 	 * Assert that the specified object is contained in the graph
 	 * 
 	 * @param obj {@link EObject}
-	 * @param graph {@link EGraphImpl}
+	 * @param graph {@link EGraph}
 	 * @throws AssertionError
 	 */
 	public static void assertObjectInGraph(EObject obj, EGraph graph) throws AssertionError {
@@ -41,7 +41,7 @@ public class Graphs {
 	 * Assert that the specified object is not contained in the graph
 	 * 
 	 * @param obj {@link EObject}
-	 * @param graph {@link EGraphImpl}
+	 * @param graph {@link EGraph}
 	 * @throws AssertionError
 	 */
 	public static void assertObjectNotInGraph(EObject obj, EGraph graph) throws AssertionError {
@@ -57,10 +57,8 @@ public class Graphs {
 	 * <li>there are no unmatched elements or changes</li>
 	 * </ul>
 	 * 
-	 * @param graph1 {@link EGraphImpl}
-	 * @param graph2 {@link EGraphImpl}
-	 * @param matchSimilarityThreshold similarity for EmfCompare's mapping. Values above (and including) this are
-	 *            considered as mapped. Range [0..1]. 0.9 is a good value to start with, adjust if problems occur.
+	 * @param graph1 {@link EGraph}
+	 * @param graph2 {@link EGraph}
 	 * @throws AssertionError
 	 */
 	public static void assertGraphsEqual(EGraph graph1, EGraph graph2) throws AssertionError {

--- a/plugins/org.eclipse.emf.henshin.tests/src/org/eclipse/emf/henshin/tests/framework/Matches.java
+++ b/plugins/org.eclipse.emf.henshin.tests/src/org/eclipse/emf/henshin/tests/framework/Matches.java
@@ -215,10 +215,10 @@ public class Matches {
 	}
 
 	/**
-	 * Asserts that a RuleApplication matches all elements from the group (not neccessarily in one match; if this is
-	 * desired, use {@link assertGroupContainedInAtLeastOneMatch})
+	 * Asserts that a RuleApplication matches all elements from the group (not necessarily in one match; if this is
+	 * desired, use {@link #assertGroupContainedInAtLeastOneMatch})
 	 * 
-	 * @param ra {@link RuleApplication}
+	 * @param rule {@link RuleApplication}
 	 * @param group {@link Collection} of {@link EObject}s
 	 * @throws AssertionError
 	 */
@@ -250,7 +250,7 @@ public class Matches {
 	 * Asserts that a {@link RuleApplication} matches all elements from the group (not neccessarily in one match) and
 	 * the match doesn't contain any objects not in the group.
 	 * 
-	 * @param ra
+	 * @param rule
 	 * @param group
 	 * @throws AssertionError
 	 */

--- a/plugins/org.eclipse.emf.henshin.tests/src/org/eclipse/emf/henshin/tests/framework/Parameters.java
+++ b/plugins/org.eclipse.emf.henshin.tests/src/org/eclipse/emf/henshin/tests/framework/Parameters.java
@@ -60,10 +60,6 @@ public class Parameters {
 
 	/**
 	 * Asserts that the {@link Match} contains no parameter mapping for "parameterName".
-	 *
-	 * @param ma
-	 * @param parameterName
-	 * @throws AssertionError
 	 */
 	public static void assertParameterNotReadableAfterApplication(UnitApplication unitApp, String parameterName) throws AssertionError {
 		try {

--- a/plugins/org.eclipse.emf.henshin.tests/src/org/eclipse/emf/henshin/tests/framework/Rules.java
+++ b/plugins/org.eclipse.emf.henshin.tests/src/org/eclipse/emf/henshin/tests/framework/Rules.java
@@ -46,7 +46,7 @@ public class Rules {
 	/**
 	 * Assert that a {@link Rule} has no match
 	 * 
-	 * @param r {@link Rule}
+	 * @param rule {@link Rule}
 	 * @parem engine {@link Engine}
 	 * @throws AssertionError
 	 */
@@ -60,7 +60,7 @@ public class Rules {
 	/**
 	 * Assert that a {@link Rule} produces exactly n matches
 	 * 
-	 * @param r {@link Rule}
+	 * @param rule {@link Rule}
 	 * @param engine {@link Engine}
 	 * @param n Number of expected matches
 	 * @throws AssertionError
@@ -76,7 +76,7 @@ public class Rules {
 	/**
 	 * Assert that a {@link Rule} can be applied multiple times
 	 * 
-	 * @param r {@link Rule}
+	 * @param rule {@link Rule}
 	 * @param engine {@link Engine}
 	 * @throws AssertionError
 	 */

--- a/plugins/org.eclipse.emf.henshin.tests/src/org/eclipse/emf/henshin/tests/framework/Tools.java
+++ b/plugins/org.eclipse.emf.henshin.tests/src/org/eclipse/emf/henshin/tests/framework/Tools.java
@@ -126,7 +126,6 @@ public class Tools {
 	 * 
 	 * @param contextFreeOclQuery context-free OCL query
 	 * @param graph {@link EGraph} the query is executed on
-	 * @return
 	 */
 	public static Collection<? extends EObject> getOCLQueryResults(String contextFreeOclQuery, EGraph graph) {
 		OCL ocl = org.eclipse.ocl.ecore.OCL.newInstance();
@@ -150,10 +149,6 @@ public class Tools {
 
 	/**
 	 * Return the first element matched by the context-free OCL query
-	 * 
-	 * @param contextFreeOclQuery
-	 * @param graph
-	 * @return
 	 */
 	public static EObject getFirstOCLResult(String contextFreeOclQuery, EGraph graph) {
 		OCL ocl = org.eclipse.ocl.ecore.OCL.newInstance();
@@ -181,9 +176,6 @@ public class Tools {
 
 	/**
 	 * get the {@link EGraph}'s first root
-	 * 
-	 * @param graph
-	 * @return
 	 */
 	public static EObject getGraphRoot(EGraph graph) {
 		return graph.getRoots().toArray(new EObject[1])[0];

--- a/plugins/org.eclipse.emf.henshin.tests/src/org/eclipse/emf/henshin/tests/framework/Units.java
+++ b/plugins/org.eclipse.emf.henshin.tests/src/org/eclipse/emf/henshin/tests/framework/Units.java
@@ -28,10 +28,10 @@ import org.eclipse.emf.henshin.model.Unit;
 public class Units {
 
 	/**
-	 * Assert that the specified {@link TransformationUnit} can be executed multiple times.
+	 * Assert that the specified {@link Unit} can be executed multiple times.
 	 * 
-	 * @param tu {@link TransformationUnit} to be executed
-	 * @param graph {@link EGraph} the {@link TransformationUnit} should be executed on
+	 * @param tu {@link Unit} to be executed
+	 * @param graph {@link EGraph} the {@link Unit} should be executed on
 	 * @throws AssertionError
 	 */
 	public static void assertTransformationUnitCanBeExecutedMultipleTimes(Unit tu, EGraph graph, Engine engine)
@@ -61,11 +61,11 @@ public class Units {
 	}
 
 	/**
-	 * Assert that the specified {@link TransformationUnit} can be executed at least n times.
+	 * Assert that the specified {@link Unit} can be executed at least n times.
 	 * 
-	 * @param tu {@link TransformationUnit} to be executed
-	 * @param graph {@link EGraph} the {@link TransformationUnit} should be executed on
-	 * @param n minimum number of times the {@link TransformationUnit} should be able to be executed
+	 * @param tu {@link Unit} to be executed
+	 * @param graph {@link EGraph} the {@link Unit} should be executed on
+	 * @param n minimum number of times the {@link Unit} should be able to be executed
 	 * @throws AssertionError
 	 */
 	public static void assertTransformationUnitCanBeExecutedNTimes(Unit tu, EGraph graph, Engine engine, int n)

--- a/plugins/org.eclipse.emf.henshin.tests/src/org/eclipse/emf/henshin/tests/uml/Association.java
+++ b/plugins/org.eclipse.emf.henshin.tests/src/org/eclipse/emf/henshin/tests/uml/Association.java
@@ -105,7 +105,7 @@ public class Association extends NamedElement {
 	 * Sets the value of the '{@link org.eclipse.emf.henshin.tests.uml.Association#getSrc <em>Src</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Src</em>' reference.
+	 * @param newSrc the new value of the '<em>Src</em>' reference.
 	 * @see #getSrc()
 	 * @generated
 	 */
@@ -155,7 +155,7 @@ public class Association extends NamedElement {
 	 * Sets the value of the '{@link org.eclipse.emf.henshin.tests.uml.Association#getDst <em>Dst</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Dst</em>' reference.
+	 * @param newDst the new value of the '<em>Dst</em>' reference.
 	 * @see #getDst()
 	 * @generated
 	 */

--- a/plugins/org.eclipse.emf.henshin.tests/src/org/eclipse/emf/henshin/tests/uml/Attribute.java
+++ b/plugins/org.eclipse.emf.henshin.tests/src/org/eclipse/emf/henshin/tests/uml/Attribute.java
@@ -94,7 +94,7 @@ public class Attribute extends NamedElement {
 	 * Sets the value of the '{@link org.eclipse.emf.henshin.tests.uml.Attribute#getType <em>Type</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Type</em>' reference.
+	 * @param newType the new value of the '<em>Type</em>' reference.
 	 * @see #getType()
 	 * @generated
 	 */

--- a/plugins/org.eclipse.emf.henshin.tests/src/org/eclipse/emf/henshin/tests/uml/Class.java
+++ b/plugins/org.eclipse.emf.henshin.tests/src/org/eclipse/emf/henshin/tests/uml/Class.java
@@ -113,7 +113,7 @@ public class Class extends NamedElement {
 	 * Sets the value of the '{@link org.eclipse.emf.henshin.tests.uml.Class#getParent <em>Parent</em>}' reference.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Parent</em>' reference.
+	 * @param newParent the new value of the '<em>Parent</em>' reference.
 	 * @see #getParent()
 	 * @generated
 	 */

--- a/plugins/org.eclipse.emf.henshin.tests/src/org/eclipse/emf/henshin/tests/uml/NamedElement.java
+++ b/plugins/org.eclipse.emf.henshin.tests/src/org/eclipse/emf/henshin/tests/uml/NamedElement.java
@@ -88,7 +88,7 @@ public abstract class NamedElement extends MinimalEObjectImpl.Container implemen
 	 * Sets the value of the '{@link org.eclipse.emf.henshin.tests.uml.NamedElement#getName <em>Name</em>}' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Name</em>' attribute.
+	 * @param newName the new value of the '<em>Name</em>' attribute.
 	 * @see #getName()
 	 * @generated
 	 */

--- a/plugins/org.eclipse.emf.henshin.text/src/org/eclipse/emf/henshin/text/validation/Henshin_textValidator.xtend
+++ b/plugins/org.eclipse.emf.henshin.text/src/org/eclipse/emf/henshin/text/validation/Henshin_textValidator.xtend
@@ -1650,7 +1650,7 @@ class Henshin_textValidator extends AbstractHenshin_textValidator {
 	/**
 	 * Fehler wenn keine Zahlenwerte in einem Multiplikations-/Divisions-Ausdruck verwendet werden
 	 * 
-	 * @param plus Zu überprüfender Multiplikations-/Divisions-Ausdruck
+	 * @param mulOrDiv Zu überprüfender Multiplikations-/Divisions-Ausdruck
 	 */
 	@Check
 	def checkTypeMulOrDiv(MulOrDivExpression mulOrDiv) {
@@ -1661,7 +1661,7 @@ class Henshin_textValidator extends AbstractHenshin_textValidator {
 	/**
 	 * Fehler wenn keine Zahlenwerte in einem Subtraktions-Ausdruck verwendet werden
 	 * 
-	 * @param plus Zu überprüfender Subtraktions-Ausdruck
+	 * @param minus Zu überprüfender Subtraktions-Ausdruck
 	 */
 	@Check
 	def checkTypeMinus(MinusExpression minus) {

--- a/plugins/variability/org.eclipse.emf.henshin.variability.configuration.ui/src/org/eclipse/emf/henshin/variability/configuration/ui/helpers/CreationMode.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.configuration.ui/src/org/eclipse/emf/henshin/variability/configuration/ui/helpers/CreationMode.java
@@ -2,9 +2,9 @@ package org.eclipse.emf.henshin.variability.configuration.ui.helpers;
 
 /**
  * This enumeration lists the different creation modes for variability aware model elements.<p>
- * {@link BASE}: Create the element in the base rule, i.e. no presence condition is set for the element.<br>
- * {@link CONFIGURATION}: Create the element in the selected configuration, regardless of what is being viewed in the editor.
- * {@link SELECTION}: Create the element in the current editor selection.
+ * {@link #BASE}: Create the element in the base rule, i.e. no presence condition is set for the element.<br>
+ * {@link #CONFIGURATION}: Create the element in the selected configuration, regardless of what is being viewed in the editor.
+ * {@link #SELECTION}: Create the element in the current editor selection.
  * 
  * @author Stefan Schulz
  *

--- a/plugins/variability/org.eclipse.emf.henshin.variability.configuration.ui/src/org/eclipse/emf/henshin/variability/ui/viewer/util/FeatureViewerContentProvider.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.configuration.ui/src/org/eclipse/emf/henshin/variability/ui/viewer/util/FeatureViewerContentProvider.java
@@ -4,6 +4,7 @@ import org.eclipse.jface.viewers.IStructuredContentProvider;
 import org.eclipse.jface.viewers.Viewer;
 
 import configuration.Configuration;
+import configuration.Feature;
 
 /**
  * Provides a {@link IStructuredContentProvider} for {@link Feature}s.

--- a/plugins/variability/org.eclipse.emf.henshin.variability.configuration.ui/src/org/eclipse/emf/henshin/variability/ui/views/VariabilityView.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.configuration.ui/src/org/eclipse/emf/henshin/variability/ui/views/VariabilityView.java
@@ -82,6 +82,7 @@ import org.eclipse.swt.widgets.Text;
 import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.ToolItem;
 import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IViewSite;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
@@ -143,7 +144,7 @@ public class VariabilityView extends ViewPart
 	}
 
 	/**
-	 * @see IViewPart.init(IViewSite)
+	 * @see IViewPart#init(IViewSite)
 	 */
 	@Override
 	public void init(IViewSite site) throws PartInitException {

--- a/plugins/variability/org.eclipse.emf.henshin.variability.mergein.refactoring/src/org/eclipse/emf/henshin/variability/mergein/refactoring/util/StringUtil.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.mergein.refactoring/src/org/eclipse/emf/henshin/variability/mergein/refactoring/util/StringUtil.java
@@ -14,11 +14,6 @@ public class StringUtil {
 	 * In the given input String, replaces all occurrences of the to-be-replaced
 	 * with the replacement String *unless* the occurrence is directly preceded
 	 * or succeeded by an alphanumeric character.
-	 * 
-	 * @param input
-	 * @param toBeReplaced
-	 * @param replacement
-	 * @return
 	 */
 	public static String cleanReplace(String input, String toBeReplaced,
 			String replacement) {

--- a/plugins/variability/org.eclipse.emf.henshin.variability.mergein.ui/src/org/eclipse/emf/henshin/variability/ui/views/CloneGroupView.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.mergein.ui/src/org/eclipse/emf/henshin/variability/ui/views/CloneGroupView.java
@@ -67,7 +67,7 @@ import org.eclipse.ui.part.ViewPart;
  * different labels and icons, if needed. Alternatively, a single label provider
  * can be shared between views in order to ensure that objects of the same type
  * are presented in the same way everywhere.
- * <p>
+ * </p>
  */
 
 public class CloneGroupView extends ViewPart {

--- a/plugins/variability/org.eclipse.emf.henshin.variability.mergein/src/org/eclipse/emf/henshin/variability/mergein/clone/JGraphTIsomorphyChecker.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.mergein/src/org/eclipse/emf/henshin/variability/mergein/clone/JGraphTIsomorphyChecker.java
@@ -16,9 +16,6 @@ import org.jgrapht.graph.DefaultDirectedGraph;
  * multi-edges.
  * 
  * @author strueber
- *
- * @param <X>
- * @param <Y>
  */
 public class JGraphTIsomorphyChecker {
 

--- a/plugins/variability/org.eclipse.emf.henshin.variability.mergein/src/org/eclipse/emf/henshin/variability/mergein/clustering/CloneHierarchy.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.mergein/src/org/eclipse/emf/henshin/variability/mergein/clustering/CloneHierarchy.java
@@ -55,8 +55,6 @@ public class CloneHierarchy {
 
 	/**
 	 * Returns all clone groups without a super clone group.
-	 * 
-	 * @return
 	 */
 	public Set<CloneGroup> getTopCloneGroups() {
 		Set<CloneGroup> result = new HashSet<CloneGroup>();

--- a/plugins/variability/org.eclipse.emf.henshin.variability.mergein/src/org/eclipse/emf/henshin/variability/mergein/clustering/extension/ExtensionCloneRelation.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.mergein/src/org/eclipse/emf/henshin/variability/mergein/clustering/extension/ExtensionCloneRelation.java
@@ -13,9 +13,6 @@ public class ExtensionCloneRelation {
 	/**
 	 * A clone group is an extension of another clone group if includes
 	 * all mappings of the other clone group and the same or a subset of its rules.
-	 * @param basis
-	 * @param extension
-	 * @return
 	 */
 	public static boolean isExtensionClone(CloneGroup basis,
 			CloneGroup extension) {

--- a/plugins/variability/org.eclipse.emf.henshin.variability.mergein/src/org/eclipse/emf/henshin/variability/mergein/conqat/HenshinToConqatGraphConverter.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.mergein/src/org/eclipse/emf/henshin/variability/mergein/conqat/HenshinToConqatGraphConverter.java
@@ -14,7 +14,7 @@ import org.eclipse.emf.henshin.variability.mergein.normalize.HenshinNode;
 /**
  * Creates Conquat compatible graph representations of Henshin rule graphs.
  * 
- * @author strüber
+ * @author strï¿½ber
  *
  */
 /**
@@ -34,9 +34,6 @@ public class HenshinToConqatGraphConverter {
 	/**
 	 * Creates the Conqat graph representation of a set of Henshin Rules, represented by
 	 * the input HenshinGraph.
-	 * 
-	 * @param henshinGraph
-	 * @return
 	 */
 	public IModelGraph createConqatGraph() {
 		IModelGraph resultGraph = new ModelGraphMock();
@@ -51,9 +48,6 @@ public class HenshinToConqatGraphConverter {
 	/**
 	 * Creates the Conqat graph representation of a Henshin Rule, represented by
 	 * the input HenshinGraph.
-	 * 
-	 * @param henshinGraph
-	 * @return
 	 */
 	public IModelGraph createConqatGraph(HenshinGraph henshinGraph) {
 		IModelGraph graph = new ModelGraphMock();

--- a/plugins/variability/org.eclipse.emf.henshin.variability.mergein/src/org/eclipse/emf/henshin/variability/mergein/mining/MiningManager.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.mergein/src/org/eclipse/emf/henshin/variability/mergein/mining/MiningManager.java
@@ -84,7 +84,6 @@ public class MiningManager {
 	 * 
 	 * @param node
 	 * @param fragment
-	 * @return
 	 */
 	public List<HenshinNode> getNodesCorrespondingToFragmentNode(
 			Node<INodeLabel, IEdgeLabel> node,
@@ -115,10 +114,6 @@ public class MiningManager {
 	/**
 	 * Returns the list of HenshinGraph edge corresponding to the given edge in
 	 * the given fragment.
-	 * 
-	 * @param node
-	 * @param fragment
-	 * @return
 	 */
 	public List<HenshinEdge> getEdgesCorrespondingToFragmentEdge(
 			Edge<INodeLabel, IEdgeLabel> edge,
@@ -153,7 +148,6 @@ public class MiningManager {
 	 * fragment.
 	 * 
 	 * @param f
-	 * @return
 	 */
 	public String printFragment(Fragment<INodeLabel, IEdgeLabel> f) {
 		return serializer.serialize(f.toGraph());
@@ -164,7 +158,6 @@ public class MiningManager {
 	 * subgraph pattern represented by the given fragment.
 	 * 
 	 * @param fragment
-	 * @return
 	 */
 	public List<Set<HenshinGraphElement>> getGraphElementsOfEmbeddings(
 			Fragment<INodeLabel, IEdgeLabel> fragment) {
@@ -263,7 +256,6 @@ public class MiningManager {
 	 * embedding.
 	 * 
 	 * @param e1
-	 * @return
 	 */
 	public Set<HenshinEdge> getSuperGraphEdges(
 			Embedding<INodeLabel, IEdgeLabel> e1) {
@@ -293,7 +285,6 @@ public class MiningManager {
 	 * by their containing HenshinGraph.
 	 * 
 	 * @param fragment
-	 * @return
 	 */
 	public Map<HenshinEdge, Map<HenshinGraph, HenshinEdge>> createHenshinEdgeMappings(
 			Fragment<INodeLabel, IEdgeLabel> fragment) {
@@ -329,7 +320,6 @@ public class MiningManager {
 	 * HenshinGraph.
 	 * 
 	 * @param fragment
-	 * @return
 	 */
 	public Map<HenshinEdge, Map<HenshinGraph, HenshinEdge>> createHenshinAttributeMappings(
 			Fragment<INodeLabel, IEdgeLabel> fragment) {

--- a/plugins/variability/org.eclipse.emf.henshin.variability.mergein/src/org/eclipse/emf/henshin/variability/mergein/mining/core/HenshinGraphToParsemisConverter.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.mergein/src/org/eclipse/emf/henshin/variability/mergein/mining/core/HenshinGraphToParsemisConverter.java
@@ -42,9 +42,6 @@ public class HenshinGraphToParsemisConverter {
 	/**
 	 * Creates the Parsemis graph representation of a Henshin Rrule, represented
 	 * by the input HenshinGraph.
-	 * 
-	 * @param entityList
-	 * @return
 	 */
 	public Graph<INodeLabel, IEdgeLabel> createParsemisGraph(
 			HenshinGraph henshinGraph) {

--- a/plugins/variability/org.eclipse.emf.henshin.variability.test/tests/org/eclipse/emf/henshin/variability/tests/parameterized/VBEngineParameterizedTest.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.test/tests/org/eclipse/emf/henshin/variability/tests/parameterized/VBEngineParameterizedTest.java
@@ -77,7 +77,6 @@ public class VBEngineParameterizedTest {
 	/**
 	 * Executes the specified test
 	 *
-	 * @param dataFile The test specification
 	 * @throws InconsistentRuleException If a inconsistent rule should be executed
 	 */
 	@Test

--- a/plugins/variability/org.eclipse.emf.henshin.variability/src/org/eclipse/emf/henshin/variability/matcher/FeatureExpression.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability/src/org/eclipse/emf/henshin/variability/matcher/FeatureExpression.java
@@ -31,10 +31,6 @@ public class FeatureExpression {
 
 	/**
 	 * Does expression 1 imply expression 2?
-	 * 
-	 * @param expr1
-	 * @param expr2
-	 * @return
 	 */
 	public static boolean implies(Sentence expr1, Sentence expr2) {
 		if (implies.containsKey(expr1)) {
@@ -88,10 +84,6 @@ public class FeatureExpression {
 
 	/**
 	 * Does expression 1 contradict expression 2?
-	 * 
-	 * @param expr1
-	 * @param expr2
-	 * @return
 	 */
 	public static boolean contradicts(Sentence expr1, Sentence expr2) {
 		if (contradicts.containsKey(expr1)) {

--- a/plugins/variability/org.eclipse.emf.henshin.variability/src/org/eclipse/emf/henshin/variability/matcher/RulePreparator.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability/src/org/eclipse/emf/henshin/variability/matcher/RulePreparator.java
@@ -69,12 +69,6 @@ public class RulePreparator {
 	 * Prepares the rule for variability-based merging and rule application:
 	 * rejected elements and removed and the "injective" flag is set. Assumes that
 	 * the reject() method has been invoked method before.
-	 * 
-	 * @param rule
-	 * @param ruleInfo
-	 * @param rejected
-	 * @param executed
-	 * @return
 	 */
 	public BitSet prepare(RuleInfo ruleInfo, Set<Sentence> rejected, boolean injectiveMatching, boolean baseRule) {
 		this.baseRule = baseRule;

--- a/plugins/variability/org.eclipse.emf.henshin.variability/src/org/eclipse/emf/henshin/variability/matcher/VariabilityAwareMatcher.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability/src/org/eclipse/emf/henshin/variability/matcher/VariabilityAwareMatcher.java
@@ -85,8 +85,7 @@ public class VariabilityAwareMatcher {
 	 * 
 	 * @param rule           The rule to be executed
 	 * @param graph          The graph on which the rule should be executed
-	 * @param initiallyTrue  All features set to 'true'
-	 * @param initiallyFalse All features set to 'false'
+	 * @param configuration  All features mapped to their respective state
 	 * @throws InconsistentRuleException If the rule is inconsistent
 	 */
 	public VariabilityAwareMatcher(Rule rule, EGraph graph, Map<String, Boolean> configuration)

--- a/plugins/variability/org.eclipse.emf.henshin.variability/src/org/eclipse/emf/henshin/variability/util/XorEncoderUtil.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability/src/org/eclipse/emf/henshin/variability/util/XorEncoderUtil.java
@@ -6,7 +6,7 @@ import java.util.Stack;
 
 /**
  * 
- * @author Daniel Strüber, Stefan Schulz
+ * @author Daniel Strï¿½ber, Stefan Schulz
  *
  */
 public class XorEncoderUtil {
@@ -15,9 +15,6 @@ public class XorEncoderUtil {
 	 * Encodes any occurrence of a xor(A,B) pattern into ((A and !B) or (A and
 	 * !B)). Works for an arbitrary number of arguments. A and B are allowed to
 	 * contain futher xor patterns, as long as parentheses are nested correctly.
-	 * 
-	 * @param presenceCondition
-	 * @return
 	 */
 	public static String encodeXor(String expression) {
 		if (!isWellFormed(expression)) {

--- a/plugins/variability/org.eclipse.emf.henshin.variability/src/org/eclipse/emf/henshin/variability/wrapper/VariabilityEdge.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability/src/org/eclipse/emf/henshin/variability/wrapper/VariabilityEdge.java
@@ -66,7 +66,6 @@ public class VariabilityEdge implements Edge, VariabilityGraphElement {
 	 * @param source Source node.
 	 * @param target Target node.
 	 * @param type Edge type.
-	 * @return The created edge.
 	 */
 	VariabilityEdge(Node source, Node target, EReference type) {
 		this(HenshinFactoryImpl.eINSTANCE.createEdge(source, target, type));

--- a/plugins/variability/org.eclipse.emf.henshin.variability/src/org/eclipse/emf/henshin/variability/wrapper/VariabilityRule.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability/src/org/eclipse/emf/henshin/variability/wrapper/VariabilityRule.java
@@ -246,7 +246,7 @@ public class VariabilityRule extends EObjectImpl implements Rule {
 	/**
 	 * Removes the given feature if it is a part of this Rule.
 	 * 
-	 * @param variabilityPoint the variability point to be removed.
+	 * @param feature the feature to be removed.
 	 */
 	public void removeFeature(String feature) {
 		if (features.getValue() == null) {
@@ -625,7 +625,6 @@ public class VariabilityRule extends EObjectImpl implements Rule {
 	}
 
 	/**
-	 * @return
 	 * @see org.eclipse.emf.henshin.model.Unit#isActivated()
 	 */
 	public boolean isActivated() {


### PR DESCRIPTION
- Adjust wrong parameter names
- Remove documented parameters that don't exist
- Remove empty parameter and return-value documentations
