### PR TITLE
[Build] Only consider severity >= high warnings from Maven-Console

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,9 +27,11 @@ pipeline {
 					discoverGitReferenceBuild referenceJob: 'eclipse.henshin/master'
 					recordIssues enabledForFailure: true, publishAllIssues: true, ignoreQualityGate: true, tools: [
 							eclipse(name: 'Compiler', pattern: '**/target/compilelogs/*.xml'),
-							mavenConsole(),
 							javaDoc()
 						], qualityGates: [[threshold: 1, type: 'NEW', unstable: true]]
+					recordIssues enabledForFailure: true, publishAllIssues: true, ignoreQualityGate: true, tools: [
+							mavenConsole(),
+						], qualityGates: [[threshold: 1, type: 'NEW_HIGH', unstable: true]]
 				}
 			}
 		}


### PR DESCRIPTION
In general the warnings collected from the Maven-Console are not very stable and therefore often cause false-negative qualitiy-gate pass, although the change in question does not cause the warning. Just collecting those warnings (and checking only for warnings of severity high or error) improves the stability of the build.

I have also looked into the existing (and sometimes new) warnings and some of them can in fact be addressed, but some would require an update of the Target-Platform respectively or of some dependencies and that's something that might take longer (https://github.com/eclipse-henshin/henshin/issues/16).
Therefore I suggest to disable the quality-gate for the Maven-Console now and re-enable it later in case the warnings are fixed or are at least stable (so that they can be accepted as new baseline).