### PR TITLE
Fix remaining JavaDoc warnings and fail the build on doc warnings/errors

### DIFF
--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/src/org/eclipse/emf/henshin/ocl2ac/tool/action/CompCond2AppCondAction.java
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/src/org/eclipse/emf/henshin/ocl2ac/tool/action/CompCond2AppCondAction.java
@@ -28,6 +28,7 @@ import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Monitor;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.IActionDelegate;
 import org.eclipse.ui.IObjectActionDelegate;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.PlatformUI;

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/src/org/eclipse/emf/henshin/ocl2ac/tool/action/GC2AppCondAction.java
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/src/org/eclipse/emf/henshin/ocl2ac/tool/action/GC2AppCondAction.java
@@ -28,6 +28,7 @@ import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Monitor;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.IActionDelegate;
 import org.eclipse.ui.IObjectActionDelegate;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.PlatformUI;

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/src/org/eclipse/emf/henshin/ocl2ac/tool/action/LaxCond2AppCondAction.java
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/src/org/eclipse/emf/henshin/ocl2ac/tool/action/LaxCond2AppCondAction.java
@@ -40,6 +40,7 @@ import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Cursor;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.IActionDelegate;
 import org.eclipse.ui.IObjectActionDelegate;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.PlatformUI;

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/src/org/eclipse/emf/henshin/ocl2ac/tool/action/LaxCond2GCAction.java
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/src/org/eclipse/emf/henshin/ocl2ac/tool/action/LaxCond2GCAction.java
@@ -40,6 +40,7 @@ import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Cursor;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.IActionDelegate;
 import org.eclipse.ui.IObjectActionDelegate;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.PlatformUI;

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/src/org/eclipse/emf/henshin/ocl2ac/tool/action/OCL2GCAction.java
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/src/org/eclipse/emf/henshin/ocl2ac/tool/action/OCL2GCAction.java
@@ -22,6 +22,7 @@ import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Cursor;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.IActionDelegate;
 import org.eclipse.ui.IObjectActionDelegate;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.PlatformUI;

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/src/org/eclipse/emf/henshin/ocl2ac/tool/commands/LaxCond2GCCommand.java
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/src/org/eclipse/emf/henshin/ocl2ac/tool/commands/LaxCond2GCCommand.java
@@ -22,7 +22,10 @@ import org.eclipse.emf.henshin.model.Node;
 import org.eclipse.emf.henshin.model.Parameter;
 import org.eclipse.emf.henshin.model.Rule;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.IActionDelegate;
 import org.eclipse.emf.henshin.ocl2ac.ocl2gc.core.Completer;
+import org.eclipse.jface.action.IAction;
+
 import laxcondition.Condition;
 import laxcondition.LaxconditionPackage;
 import laxcondition.util.extensions.LaxConditionSimplifier;

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.utils/src/org/eclipse/emf/henshin/ocl2ac/utils/viewer/PDFViewer.java
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.utils/src/org/eclipse/emf/henshin/ocl2ac/utils/viewer/PDFViewer.java
@@ -20,7 +20,7 @@ public class PDFViewer extends ViewPart {
 	public static String pdfpath;
 	public static Browser browser;
 
-	/**
+	/*
 	 * @wbp.parser.constructor
 	 */
 	public PDFViewer() {

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/navigator/HenshinNavigatorLabelProvider.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/navigator/HenshinNavigatorLabelProvider.java
@@ -59,7 +59,7 @@ import org.eclipse.ui.navigator.ICommonLabelProvider;
 
 /**
  * @generated
- * @implements IColorProvider
+ * @see IColorProvider
  */
 @SuppressWarnings("unused")
 public class HenshinNavigatorLabelProvider extends LabelProvider

--- a/plugins/org.eclipse.emf.henshin.edit/src/org/eclipse/emf/henshin/commands/dnd/DelegatingWrapperFeatureDragAndDropCommand.java
+++ b/plugins/org.eclipse.emf.henshin.edit/src/org/eclipse/emf/henshin/commands/dnd/DelegatingWrapperFeatureDragAndDropCommand.java
@@ -25,6 +25,7 @@ import org.eclipse.emf.edit.command.DragAndDropFeedback;
 import org.eclipse.emf.edit.command.MoveCommand;
 import org.eclipse.emf.edit.command.RemoveCommand;
 import org.eclipse.emf.edit.domain.EditingDomain;
+import org.eclipse.emf.edit.provider.DelegatingWrapperItemProvider;
 import org.eclipse.emf.edit.provider.IWrapperItemProvider;
 
 /**

--- a/plugins/org.eclipse.emf.henshin.edit/src/org/eclipse/emf/henshin/commands/dnd/NonContainmentTransientIPDragAndDropCommand.java
+++ b/plugins/org.eclipse.emf.henshin.edit/src/org/eclipse/emf/henshin/commands/dnd/NonContainmentTransientIPDragAndDropCommand.java
@@ -23,6 +23,7 @@ import org.eclipse.emf.edit.command.SetCommand;
 import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.emf.edit.provider.IWrapperItemProvider;
 import org.eclipse.emf.henshin.model.Unit;
+import org.eclipse.emf.henshin.provider.trans.TransientItemProvider;
 
 /**
  * 

--- a/plugins/org.eclipse.emf.henshin.edit/src/org/eclipse/emf/henshin/provider/trans/NestedConditionMappingItemProvider.java
+++ b/plugins/org.eclipse.emf.henshin.edit/src/org/eclipse/emf/henshin/provider/trans/NestedConditionMappingItemProvider.java
@@ -23,7 +23,9 @@ import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.emf.henshin.commands.NegligentRemoveCommand;
 import org.eclipse.emf.henshin.model.HenshinFactory;
 import org.eclipse.emf.henshin.model.HenshinPackage;
+import org.eclipse.emf.henshin.model.Mapping;
 import org.eclipse.emf.henshin.model.NestedCondition;
+import org.eclipse.emf.henshin.model.Rule;
 
 /**
  * This is the item provider for a {@link Mapping} object being referred to by

--- a/plugins/org.eclipse.emf.henshin.editor/src/org/eclipse/emf/henshin/editor/commands/CreateMappedNodeCommand.java
+++ b/plugins/org.eclipse.emf.henshin.editor/src/org/eclipse/emf/henshin/editor/commands/CreateMappedNodeCommand.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import org.eclipse.emf.common.command.AbstractCommand;
+import org.eclipse.emf.henshin.model.Graph;
 import org.eclipse.emf.henshin.model.HenshinFactory;
 import org.eclipse.emf.henshin.model.Mapping;
 import org.eclipse.emf.henshin.model.Node;

--- a/plugins/org.eclipse.emf.henshin.editor/src/org/eclipse/emf/henshin/editor/commands/CreateMappingCommand.java
+++ b/plugins/org.eclipse.emf.henshin.editor/src/org/eclipse/emf/henshin/editor/commands/CreateMappingCommand.java
@@ -145,10 +145,6 @@ public class CreateMappingCommand extends CompoundCommand {
 	/**
 	 * Returns true is source and target are contained in the LHS and RHS of the
 	 * same rule.
-	 * 
-	 * @param source
-	 * @param target
-	 * @return
 	 */
 	protected boolean isUnmappedLhsRhsPairFromSameRule(Node source, Node target) {
 		return source.getGraph().isLhs()
@@ -161,11 +157,6 @@ public class CreateMappingCommand extends CompoundCommand {
 	 * Checks if <code>sourceNode</code> or <code>targetNode</code> are involved
 	 * in a mapping already, being origin or image respectively, contained in
 	 * <code>mappings</code>.
-	 * 
-	 * @param sourceNode
-	 * @param targetNode
-	 * @param mappings
-	 * @return
 	 */
 	protected boolean isUnmapped(Node sourceNode, Node targetNode, Collection<Mapping> mappings) {
 		for (Mapping mapping : mappings) {

--- a/plugins/org.eclipse.emf.henshin.editor/src/org/eclipse/emf/henshin/editor/commands/DiscardInFavorOfChildFormulaCommand.java
+++ b/plugins/org.eclipse.emf.henshin.editor/src/org/eclipse/emf/henshin/editor/commands/DiscardInFavorOfChildFormulaCommand.java
@@ -10,6 +10,7 @@
 package org.eclipse.emf.henshin.editor.commands;
 
 import org.eclipse.emf.common.command.AbstractCommand;
+import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.henshin.model.BinaryFormula;
 import org.eclipse.emf.henshin.model.Formula;
 

--- a/plugins/org.eclipse.emf.henshin.editor/src/org/eclipse/emf/henshin/editor/commands/MenuContributor.java
+++ b/plugins/org.eclipse.emf.henshin.editor/src/org/eclipse/emf/henshin/editor/commands/MenuContributor.java
@@ -12,6 +12,7 @@ package org.eclipse.emf.henshin.editor.commands;
 import java.util.List;
 
 import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.common.command.CommandStack;
 import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.emf.henshin.presentation.HenshinEditorPlugin;
 import org.eclipse.jface.action.Action;
@@ -67,9 +68,6 @@ public abstract class MenuContributor {
 	
 	/**
 	 * Convenience method to retrieve labels from the plugin's properties.
-	 * 
-	 * @param key
-	 * @return
 	 */
 	protected String getLabel(String key) {
 		return HenshinEditorPlugin.INSTANCE.getString(propertyPrefix + key);
@@ -79,9 +77,6 @@ public abstract class MenuContributor {
 	 * Creates a disabled {@link Action} as a workaround to insert labels.
 	 * Convenient to display explanations why a certain action is not applicable
 	 * in the given context.
-	 * 
-	 * @param label
-	 * @return
 	 */
 	protected IAction createUnrunnableItem(final String label) {
 		return new Action() {
@@ -101,10 +96,6 @@ public abstract class MenuContributor {
 	/**
 	 * Build an {@link Action} with the given label, that executes the given
 	 * {@link Command} on {@link Action#run()}.
-	 * 
-	 * @param label
-	 * @param cmd
-	 * @return
 	 */
 	protected IAction createAction(final String label, final Command cmd) {
 		

--- a/plugins/org.eclipse.emf.henshin.editor/src/org/eclipse/emf/henshin/editor/commands/PropagateImportsCommand.java
+++ b/plugins/org.eclipse.emf.henshin.editor/src/org/eclipse/emf/henshin/editor/commands/PropagateImportsCommand.java
@@ -21,6 +21,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.edit.command.CommandParameter;
+import org.eclipse.emf.edit.command.PasteFromClipboardCommand;
 import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.emf.henshin.model.Attribute;
 import org.eclipse.emf.henshin.model.Edge;

--- a/plugins/org.eclipse.emf.henshin.editor/src/org/eclipse/emf/henshin/editor/commands/RemoveNegationCommand.java
+++ b/plugins/org.eclipse.emf.henshin.editor/src/org/eclipse/emf/henshin/editor/commands/RemoveNegationCommand.java
@@ -13,6 +13,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 import org.eclipse.emf.common.command.AbstractCommand;
+import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.henshin.model.Formula;
 import org.eclipse.emf.henshin.model.Not;
 

--- a/plugins/org.eclipse.emf.henshin.editor/src/org/eclipse/emf/henshin/editor/menuContributors/CreateMappingCommandMenuContributor.java
+++ b/plugins/org.eclipse.emf.henshin.editor/src/org/eclipse/emf/henshin/editor/menuContributors/CreateMappingCommandMenuContributor.java
@@ -16,6 +16,7 @@ import org.eclipse.emf.henshin.editor.commands.CreateMappingCommand;
 import org.eclipse.emf.henshin.editor.commands.CreateParameterMappingCommand;
 import org.eclipse.emf.henshin.editor.commands.MenuContributor;
 import org.eclipse.emf.henshin.editor.commands.QuantUtil;
+import org.eclipse.emf.henshin.model.Mapping;
 import org.eclipse.emf.henshin.model.Node;
 import org.eclipse.emf.henshin.model.Parameter;
 import org.eclipse.emf.henshin.model.Unit;

--- a/plugins/org.eclipse.emf.henshin.editor/src/org/eclipse/emf/henshin/editor/menuContributors/CreateNestedConditionMenuContributor.java
+++ b/plugins/org.eclipse.emf.henshin.editor/src/org/eclipse/emf/henshin/editor/menuContributors/CreateNestedConditionMenuContributor.java
@@ -22,6 +22,7 @@ import org.eclipse.emf.henshin.editor.commands.WrapFormulaInJunctionCommand;
 import org.eclipse.emf.henshin.model.BinaryFormula;
 import org.eclipse.emf.henshin.model.Graph;
 import org.eclipse.emf.henshin.model.HenshinPackage;
+import org.eclipse.emf.henshin.model.NestedCondition;
 import org.eclipse.emf.henshin.model.Node;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;

--- a/plugins/org.eclipse.emf.henshin.editor/src/org/eclipse/emf/henshin/editor/util/HtmlTipSupport.java
+++ b/plugins/org.eclipse.emf.henshin.editor/src/org/eclipse/emf/henshin/editor/util/HtmlTipSupport.java
@@ -9,6 +9,7 @@
  */
 package org.eclipse.emf.henshin.editor.util;
 
+import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.FocusAdapter;

--- a/plugins/org.eclipse.emf.henshin.editor/src/org/eclipse/emf/henshin/presentation/CustomizedHenshinActionBarContributor.java
+++ b/plugins/org.eclipse.emf.henshin.editor/src/org/eclipse/emf/henshin/presentation/CustomizedHenshinActionBarContributor.java
@@ -23,6 +23,7 @@ import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.emf.edit.domain.IEditingDomainProvider;
 import org.eclipse.emf.edit.provider.ITreeItemContentProvider;
 import org.eclipse.emf.edit.provider.IWrapperItemProvider;
+import org.eclipse.emf.henshin.editor.commands.MenuContributor;
 import org.eclipse.emf.henshin.editor.menuContributors.CleanUpCommandMenuContributor;
 import org.eclipse.emf.henshin.editor.menuContributors.CompleteMultiRulesCommandMenuContributor;
 import org.eclipse.emf.henshin.editor.menuContributors.CopySubgraphMenuContributor;
@@ -45,6 +46,7 @@ import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.action.Separator;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
+import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.ui.IEditorPart;
 
 /**

--- a/plugins/org.eclipse.emf.henshin.examples/src/org/eclipse/emf/henshin/examples/java2statemachine/Java2StateMachine.java
+++ b/plugins/org.eclipse.emf.henshin.examples/src/org/eclipse/emf/henshin/examples/java2statemachine/Java2StateMachine.java
@@ -30,8 +30,8 @@ import org.eclipse.emf.henshin.model.resource.HenshinResourceSet;
 /**
  * M2M transformation with a JaMoPP Java model as source model and a state
  * machine model as target. This is an implementation in terms of case study 1
- * of TTC2011 (http://planet-research20.org/ttc2011/index.php?option=com_content
- * &view=article&id=118&Itemid=160).
+ * of TTC2011 ({@code http://planet-research20.org/ttc2011/index.php?option=com_content
+ * &view=article&id=118&Itemid=160}).
  * 
  * @author Johannes Tietje
  * @author Stefan Jurack

--- a/plugins/org.eclipse.emf.henshin.examples/src/org/eclipse/emf/henshin/examples/metamodelevolution/Evolution1.java
+++ b/plugins/org.eclipse.emf.henshin.examples/src/org/eclipse/emf/henshin/examples/metamodelevolution/Evolution1.java
@@ -56,7 +56,7 @@ import org.eclipse.emf.henshin.model.resource.HenshinResourceSet;
  * performed by the Henshin interpreter.
  * <p>
  * Our case study is dealing with the evolution of a Petri net meta-model. It
- * contains nodes <tt>Place</tt> and <tt>Transition</tt> with direct
+ * contains nodes {@code Place} and {@code Transition} with direct
  * bidirectional references between them. The evolution intends to replace such
  * direct bidirectional references by a reference class. This might by useful
  * e.g. to introduce additional attributes according to this relation. However,

--- a/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/debug/HenshinDebugValue.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/debug/HenshinDebugValue.java
@@ -1,6 +1,8 @@
 package org.eclipse.emf.henshin.interpreter.debug;
 
 import java.util.Arrays;
+import java.util.List;
+
 import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.model.IDebugTarget;
 import org.eclipse.debug.core.model.IValue;
@@ -30,7 +32,7 @@ public abstract class HenshinDebugValue extends HenshinDebugElement implements I
 	 * <ol>
 	 * <li>an EObject</li>
 	 * <li>a {@link List} of objects (in this case the same rules apply for the list elements)</li>
-	 * <li>an object that provides a meaningful toString(), as that will be used for all other objects</>
+	 * <li>an object that provides a meaningful toString(), as that will be used for all other objects</li>
 	 * </ol>
 	 * @param target the associated debug target
 	 * @param graph an {@link EGraph} that is used to retrieve a string label for this value, or <code>null</code>

--- a/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/impl/LoggingApplicationMonitor.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/impl/LoggingApplicationMonitor.java
@@ -20,6 +20,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.xmi.XMIResource;
+import org.eclipse.emf.henshin.interpreter.ApplicationMonitor;
 import org.eclipse.emf.henshin.interpreter.Assignment;
 import org.eclipse.emf.henshin.interpreter.EGraph;
 import org.eclipse.emf.henshin.interpreter.Match;

--- a/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/impl/ProfilingApplicationMonitor.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/impl/ProfilingApplicationMonitor.java
@@ -12,6 +12,7 @@ package org.eclipse.emf.henshin.interpreter.impl;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.eclipse.emf.henshin.interpreter.ApplicationMonitor;
 import org.eclipse.emf.henshin.interpreter.RuleApplication;
 import org.eclipse.emf.henshin.interpreter.UnitApplication;
 import org.eclipse.emf.henshin.model.Rule;

--- a/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/impl/UnitApplicationImpl.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/impl/UnitApplicationImpl.java
@@ -22,6 +22,7 @@ import org.eclipse.emf.henshin.interpreter.EGraph;
 import org.eclipse.emf.henshin.interpreter.Engine;
 import org.eclipse.emf.henshin.interpreter.InterpreterFactory;
 import org.eclipse.emf.henshin.interpreter.RuleApplication;
+import org.eclipse.emf.henshin.interpreter.UnitApplication;
 import org.eclipse.emf.henshin.interpreter.monitoring.PerformanceMonitor;
 import org.eclipse.emf.henshin.model.ConditionalUnit;
 import org.eclipse.emf.henshin.model.HenshinPackage;

--- a/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/matching/conditions/DebugApplicationCondition.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/matching/conditions/DebugApplicationCondition.java
@@ -35,6 +35,7 @@ import org.eclipse.emf.henshin.interpreter.debug.HenshinStackFrame;
 import org.eclipse.emf.henshin.interpreter.info.RuleInfo;
 import org.eclipse.emf.henshin.interpreter.matching.constraints.AttributeConstraint;
 import org.eclipse.emf.henshin.interpreter.matching.constraints.BinaryConstraint;
+import org.eclipse.emf.henshin.interpreter.matching.constraints.Constraint;
 import org.eclipse.emf.henshin.interpreter.matching.constraints.ContainmentConstraint;
 import org.eclipse.emf.henshin.interpreter.matching.constraints.DanglingConstraint;
 import org.eclipse.emf.henshin.interpreter.matching.constraints.DomainSlot;

--- a/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/matching/constraints/DanglingConstraint.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/matching/constraints/DanglingConstraint.java
@@ -24,7 +24,7 @@ import org.eclipse.emf.henshin.interpreter.EGraph;
  * This constraint checks whether the value of an EReference contains objects
  * from the target domain.
  * 
- * @authot Enrico Biermann, Christian Krause
+ * @author Enrico Biermann, Christian Krause
  */
 public class DanglingConstraint implements Constraint {
 

--- a/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/matching/constraints/Solution.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/matching/constraints/Solution.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.henshin.interpreter.Match;
 import org.eclipse.emf.henshin.interpreter.matching.conditions.ConditionHandler;
 
 /**

--- a/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/util/EcoreCopier.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/util/EcoreCopier.java
@@ -7,6 +7,7 @@ import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EGenericType;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.ecore.ETypedElement;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecore.util.EcoreUtil.Copier;
 

--- a/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/util/HenshinEGraph.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/util/HenshinEGraph.java
@@ -24,6 +24,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.emf.henshin.interpreter.EGraph;
 import org.eclipse.emf.henshin.interpreter.impl.EGraphImpl;
 import org.eclipse.emf.henshin.model.Attribute;
 import org.eclipse.emf.henshin.model.Edge;

--- a/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/util/InterpreterUtil.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/util/InterpreterUtil.java
@@ -532,7 +532,7 @@ public class InterpreterUtil {
 	 * @param rule Rule to be matched.
 	 * @param graph Target graph.
 	 * @param partialMatch Partial match or <code>null</code>.
-	 * @return <code>true</code> if the <code>rule<code> is applicable on the <code>graph<code>.
+	 * @return <code>true</code> if the <code>rule</code> is applicable on the <code>graph</code>.
 	 */
 	public boolean isApplicable(Engine engine, Rule rule, EGraph graph, Match partialMatch){
 		Match match = this.findSingleMatch(engine, rule, graph, partialMatch);

--- a/plugins/org.eclipse.emf.henshin.model/src/org/eclipse/emf/henshin/model/Action.java
+++ b/plugins/org.eclipse.emf.henshin.model/src/org/eclipse/emf/henshin/model/Action.java
@@ -15,7 +15,6 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * <p>
  * This class represents an action of a {@link GraphElement}. Actions consist of:
  * <ul>
  * <li>an action type,</li>
@@ -23,13 +22,11 @@ import java.util.List;
  * <li>a possibly empty path (only if the multi flag is <code>true</code>),</li>
  * <li>an optional fragment.</li>
  * </ul>
- * </p>
  * <p>
  * Since version 0.9.3, the syntax of actions is as follows:
  * ...
  * </p>
  * 
- * <p>
  * Some basic examples (all examples shown with surrounding &laquo;..&raquo;):
  * <ul>
  * <li><span style="color:gray">&laquo;preserve&raquo;</span> Preserve a graph element.</li>
@@ -38,17 +35,13 @@ import java.util.List;
  * <li><span style="color:brown">&laquo;require&raquo;</span> Require the existence of a graph element.</li>
  * <li><span style="color:blue">&laquo;forbid&raquo;</span> Forbid the existence of a graph element.</li>
  * </ul>
- * </p>
  * 
- * <p>
  * Examples of named positive and negative application conditions (PACs and NACs):
  * <ul>
  * <li><span style="color:brown">&laquo;require#1&raquo;</span> Graph element is part of a PAC named <i>1</i>.</li>
  * <li><span style="color:blue">&laquo;forbid#myNAC&raquo;</span> Graph is element of a NAC named <i>myNAC</i>.</li>
  * </ul>
- * </p>
  * 
- * <p>
  * Examples of (nested) multi-rules:
  * <ul>
  * <li><span style="color:gray">&laquo;preserve*&raquo;</span> Preserve all matching graph elements (default multi-rule).</li>
@@ -57,7 +50,6 @@ import java.util.List;
  * <li><span style="color:brown">&laquo;require*&#47;my/nested/rule#1&raquo;</span> Named PAC in a nested multi-rule.</li>
  * <li><span style="color:blue">&laquo;forbid*&#47;my/nested/rule#myNAC&raquo;</span> Named NAC in a nested multi-rule.</li>
  * </ul>
- * </p>
  * 
  * @author Christian Krause
  * @author Stefan Jurack

--- a/plugins/org.eclipse.emf.henshin.model/src/org/eclipse/emf/henshin/model/util/RuleGeneralizer.java
+++ b/plugins/org.eclipse.emf.henshin.model/src/org/eclipse/emf/henshin/model/util/RuleGeneralizer.java
@@ -13,7 +13,7 @@ import org.eclipse.emf.henshin.model.Node;
 import org.eclipse.emf.henshin.model.Rule;
 
 /**
- * Generalizes a rule by making each << preserve >> and << delete >> node as abstract as possible.
+ * Generalizes a rule by making each {@code preserve} and {@code delete} node as abstract as possible.
  * 
  * 
  * @author Timo Kehrer, Manuel Ohrndorf
@@ -21,7 +21,7 @@ import org.eclipse.emf.henshin.model.Rule;
 public class RuleGeneralizer {
 
 	/**
-	 * Makes each << preserve >> and << delete >> node as abstract as possible.
+	 * Makes each {@code preserve} and {@code delete} node as abstract as possible.
 	 * 
 	 * @param rule The rule to be generalized.
 	 */

--- a/plugins/org.eclipse.emf.henshin.multicda.cda/src/org/eclipse/emf/henshin/multicda/cda/Pushout.java
+++ b/plugins/org.eclipse.emf.henshin.multicda.cda/src/org/eclipse/emf/henshin/multicda/cda/Pushout.java
@@ -57,19 +57,15 @@ public class Pushout {
 	private Graph shadowGraph;
 
 	/**
-	 * Creates Pushout of rule1.Lhs() <-- S --> rule2.Lhs() and rule1.Lhs() --> G <-- rule2.Lhs()
+	 * Creates Pushout of {@code rule1.Lhs() <-- S --> rule2.Lhs()} and {@code rule1.Lhs() --> G <-- rule2.Lhs()}
 	 * Pushout validation is on
-	 * 
-	 * @param rule1
-	 * @param l1Sl2
-	 * @param rule2
 	 */
 	public Pushout(Rule rule1, Span l1Sl2, Rule rule2) {
 		this(rule1.getLhs(), l1Sl2, rule2.getLhs(), true);
 	}
 
 	/**
-	 * Creates Pushout of rule1.Lhs() <-- S --> rule2.Lhs() and rule1.Lhs() --> G <-- rule2.Lhs()
+	 * Creates Pushout of {@code rule1.Lhs() <-- S --> rule2.Lhs()} and {@code rule1.Lhs() --> G <-- rule2.Lhs()}
 	 * 
 	 * @param validate turns the pushout validation on or of
 	 */

--- a/plugins/org.eclipse.emf.henshin.multicda.cpa.ui/src/org/eclipse/emf/henshin/multicda/cpa/ui/results/MultiPageEditorContributor.java
+++ b/plugins/org.eclipse.emf.henshin.multicda.cpa.ui/src/org/eclipse/emf/henshin/multicda/cpa/ui/results/MultiPageEditorContributor.java
@@ -15,6 +15,7 @@ import org.eclipse.jface.action.IStatusLineManager;
 import org.eclipse.jface.action.IToolBarManager;
 import org.eclipse.ui.IActionBars;
 import org.eclipse.ui.IActionBars2;
+import org.eclipse.ui.IEditorActionBarContributor;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.part.EditorActionBarContributor;
@@ -38,7 +39,7 @@ public class MultiPageEditorContributor extends EditorActionBarContributor {
 	private IWorkbenchPage page;
 
 	/**
-	 * Creates an empty editor action bar contributor. The action bars are furnished later via the <code>init method.
+	 * Creates an empty editor action bar contributor. The action bars are furnished later via the {@code init} method.
 	 */
 	public MultiPageEditorContributor() {
 	}
@@ -46,7 +47,7 @@ public class MultiPageEditorContributor extends EditorActionBarContributor {
 	/**
 	 * Contributes to the given menu.
 	 * <p>
-	 * The <code>EditorActionBarContributor implementation of this method
+	 * The  {@link EditorActionBarContributor} implementation of this method
 	 * does nothing. Subclasses may reimplement to add to the menu portion of this
 	 * contribution.
 	 * </p>
@@ -59,7 +60,7 @@ public class MultiPageEditorContributor extends EditorActionBarContributor {
 	/**
 	 * Contributes to the given status line.
 	 * <p>
-	 * The <code>EditorActionBarContributor implementation of this method
+	 * The {@link EditorActionBarContributor} implementation of this method
 	 * does nothing. Subclasses may reimplement to add to the status line portion of
 	 * this contribution.
 	 * </p>
@@ -72,7 +73,7 @@ public class MultiPageEditorContributor extends EditorActionBarContributor {
 	/**
 	 * Contributes to the given tool bar.
 	 * <p>
-	 * The <code>EditorActionBarContributor implementation of this method
+	 * The  {@link EditorActionBarContributor} implementation of this method
 	 * does nothing. Subclasses may reimplement to add to the tool bar portion of
 	 * this contribution.
 	 * </p>
@@ -85,7 +86,7 @@ public class MultiPageEditorContributor extends EditorActionBarContributor {
 	/**
 	 * Contributes to the given cool bar.
 	 * <p>
-	 * The <code>EditorActionBarContributor implementation of this method
+	 * The  {@link EditorActionBarContributor} implementation of this method
 	 * does nothing. Subclasses may reimplement to add to the cool bar portion of
 	 * this contribution. There can only be contributions from a cool bar or a tool bar.
 	 * </p>
@@ -116,17 +117,17 @@ public class MultiPageEditorContributor extends EditorActionBarContributor {
 	}
 
 	/**
-	 * The <code>EditorActionBarContributor implementation of this 
-	 * <code>IEditorActionBarContributor method does nothing,
-	 * subclasses may override.
+	 * The  {@link EditorActionBarContributor} implementation of this
+	 *  {@link IEditorActionBarContributor} method does nothing, subclasses may
+	 * override.
 	 */
 	public void dispose() {
 	}
 
 	/**
-	 * The <code>EditorActionBarContributor implementation of this 
-	 * <code>IEditorActionBarContributor method remembers the page
-	 * then forwards the call to <code>init(IActionBars) for
+	 * The  {@link EditorActionBarContributor} implementation of this 
+	 *  {@link IEditorActionBarContributor} method remembers the page
+	 * then forwards the call to  {@link #init(IActionBars)} for
 	 * backward compatibility
 	 */
 	public void init(IActionBars bars, IWorkbenchPage page) {
@@ -137,13 +138,12 @@ public class MultiPageEditorContributor extends EditorActionBarContributor {
 	/**
 	 * This method calls:
 	 * <ul>
-	 * <li>contributeToMenu with bars' menu manager
+	 * <li>contributeToMenu with bars' menu manager</li>
 	 * <li>contributeToToolBar with bars' tool bar manager</li>
-	 * <li>contributeToCoolBar with bars' cool bar manager if <code>IActionBars is of extended type IActionBars2 
-	 *  <li>contributeToStatusLine with bars' status line
-	 *    manager</li>
+	 * <li>contributeToCoolBar with bars' cool bar manager if {@link IActionBars} is of extended type IActionBars2</li>
+	 *  <li>contributeToStatusLine with bars' status line manager</li>
 	 * </ul>
-	 * The given action bars are also remembered and made accessible via <code>getActionBars.
+	 * The given action bars are also remembered and made accessible via {@link #getActionBars()}.
 	 * 
 	 * @param bars the action bars
 	 */
@@ -161,7 +161,7 @@ public class MultiPageEditorContributor extends EditorActionBarContributor {
 	/**
 	 * Sets the active editor for the contributor.
 	 * <p>
-	 * The <code>EditorActionBarContributor implementation of this method does
+	 * The {@link EditorActionBarContributor} implementation of this method does
 	 * nothing. Subclasses may reimplement. This generally entails disconnecting
 	 * from the old editor, connecting to the new editor, and updating the actions
 	 * to reflect the new editor.

--- a/plugins/org.eclipse.emf.henshin.multicda.cpa/src/org/eclipse/emf/henshin/multicda/cpa/UnsupportedRuleException.java
+++ b/plugins/org.eclipse.emf.henshin.multicda.cpa/src/org/eclipse/emf/henshin/multicda/cpa/UnsupportedRuleException.java
@@ -82,7 +82,7 @@ public class UnsupportedRuleException extends Exception {
 	/**
 	 * Extended constructor for unsupported multiple imports per module.
 	 * 
-	 * @param rule The <code>rule</rule> in which the multiple imports occur.
+	 * @param rule The <code>rule</code> in which the multiple imports occur.
 	 */
 	public UnsupportedRuleException(Rule rule) {
 		super(multipleDomainImport);

--- a/plugins/org.eclipse.emf.henshin.multicda.cpa/src/org/eclipse/emf/henshin/multicda/cpa/persist/CriticalPairNode.java
+++ b/plugins/org.eclipse.emf.henshin.multicda.cpa/src/org/eclipse/emf/henshin/multicda/cpa/persist/CriticalPairNode.java
@@ -55,18 +55,18 @@ public class CriticalPairNode {
 	}
 
 	/**
-	 * Sets the <code>TreeFolder> in which this <code>CriticalPairdNode</code> shall be contained.
+	 * Sets the <code>TreeFolder</code> in which this <code>CriticalPairdNode</code> shall be contained.
 	 * 
-	 * @param containgTreeFolder The <code>TreeFolder> in which this <code>CriticalPairdNode</code> shall be contained.
+	 * @param containgTreeFolder The <code>TreeFolder</code> in which this <code>CriticalPairdNode</code> shall be contained.
 	 */
 	public void setParent(TreeFolder containgTreeFolder) {
 		parent = containgTreeFolder;
 	}
 
 	/**
-	 * Returns the <code>TreeFolder> in which this <code>CriticalPairdNode</code> is contained.
+	 * Returns the <code>TreeFolder</code> in which this <code>CriticalPairdNode</code> is contained.
 	 * 
-	 * @return The <code>TreeFolder> in which this <code>CriticalPairdNode</code> is contained.
+	 * @return The <code>TreeFolder</code> in which this <code>CriticalPairdNode</code> is contained.
 	 */
 	public TreeFolder getParent() {
 		return parent;

--- a/plugins/org.eclipse.emf.henshin.multicda.cpa/src/org/eclipse/emf/henshin/multicda/cpa/persist/SpanNode.java
+++ b/plugins/org.eclipse.emf.henshin.multicda.cpa/src/org/eclipse/emf/henshin/multicda/cpa/persist/SpanNode.java
@@ -63,18 +63,18 @@ public class SpanNode extends TreeFolder {
 	}
 
 	/**
-	 * Sets the <code>TreeFolder> in which this <code>CriticalPairdNode</code> shall be contained.
+	 * Sets the <code>TreeFolder</code> in which this <code>CriticalPairdNode</code> shall be contained.
 	 * 
-	 * @param containgTreeFolder The <code>TreeFolder> in which this <code>CriticalPairdNode</code> shall be contained.
+	 * @param containgTreeFolder The <code>TreeFolder</code> in which this <code>CriticalPairdNode</code> shall be contained.
 	 */
 	public void setParent(TreeFolder containgTreeFolder) {
 		parent = containgTreeFolder;
 	}
 
 	/**
-	 * Returns the <code>TreeFolder> in which this <code>CriticalPairdNode</code> is contained.
+	 * Returns the <code>TreeFolder</code> in which this <code>CriticalPairdNode</code> is contained.
 	 * 
-	 * @return The <code>TreeFolder> in which this <code>CriticalPairdNode</code> is contained.
+	 * @return The <code>TreeFolder</code> in which this <code>CriticalPairdNode</code> is contained.
 	 */
 	public TreeFolder getParent() {
 		return parent;

--- a/plugins/org.eclipse.emf.henshin.statespace/src/org/eclipse/emf/henshin/statespace/Model.java
+++ b/plugins/org.eclipse.emf.henshin.statespace/src/org/eclipse/emf/henshin/statespace/Model.java
@@ -10,13 +10,13 @@
 package org.eclipse.emf.henshin.statespace;
 
 import org.eclipse.emf.common.util.EList;
-
 import org.eclipse.emf.common.util.EMap;
 
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 
 import org.eclipse.emf.ecore.resource.Resource;
+
 import org.eclipse.emf.henshin.interpreter.EGraph;
 import org.eclipse.emf.henshin.interpreter.Match;
 
@@ -33,16 +33,16 @@ public interface Model extends EObject {
 	 * Get the resource that contains the actual model elements.
 	 * @return the value of the '<em>Resource</em>' attribute.
 	 * @see org.eclipse.emf.henshin.statespace.StateSpacePackage#getModel_Resource()
-	 * @model transient="true"
+	 * @model transient="true" changeable="false"
 	 * @generated
 	 */
 	Resource getResource();
-	
+
 	/**
 	 * Get the associated {@link EGraph} instance for this model.
 	 * @return the value of the '<em>EGraph</em>' attribute.
 	 * @see org.eclipse.emf.henshin.statespace.StateSpacePackage#getModel_EGraph()
-	 * @model dataType="org.eclipse.emf.henshin.statespace.EmfGraph" transient="true" changeable="false"
+	 * @model dataType="org.eclipse.emf.henshin.statespace.EGraph" transient="true" changeable="false"
 	 * @generated
 	 */
 	EGraph getEGraph();
@@ -51,7 +51,7 @@ public interface Model extends EObject {
 	 * Get the object hash codes of this state model
 	 * @return the value of the '<em>Object Hash Codes</em>' map.
 	 * @see org.eclipse.emf.henshin.statespace.StateSpacePackage#getModel_ObjectHashCodes()
-	 * @model mapType="org.eclipse.emf.henshin.statespace.EObjectIntegerMapEntry<org.eclipse.emf.ecore.EObject, org.eclipse.emf.ecore.EIntegerObject>"
+	 * @model mapType="org.eclipse.emf.henshin.statespace.EObjectIntegerMapEntry&lt;org.eclipse.emf.ecore.EObject, org.eclipse.emf.ecore.EIntegerObject&gt;"
 	 * @generated
 	 */
 	EMap<EObject, Integer> getObjectHashCodes();
@@ -59,7 +59,8 @@ public interface Model extends EObject {
 	/**
 	 * Get the object keys map for this state model.
 	 * @return the value of the '<em>Object Keys</em>' map.
-	 * @model mapType="org.eclipse.emf.henshin.statespace.ObjectKey<org.eclipse.emf.ecore.EObject, org.eclipse.emf.ecore.EIntegerObject>"
+	 * @see org.eclipse.emf.henshin.statespace.StateSpacePackage#getModel_ObjectKeysMap()
+	 * @model mapType="org.eclipse.emf.henshin.statespace.EObjectIntegerMapEntry&lt;org.eclipse.emf.ecore.EObject, org.eclipse.emf.ecore.EIntegerObject&gt;"
 	 * @generated
 	 */
 	EMap<EObject, Integer> getObjectKeysMap();
@@ -68,7 +69,9 @@ public interface Model extends EObject {
 	 * Get the object keys of this state model as an integer array.
 	 * This is derived from {@link #getObjectKeysMap()}.
 	 * @return the value of the '<em>Object Keys</em>' attribute.
-	 * @model dataType="org.eclipse.emf.henshin.statespace.IntegerArray" transient="true" changeable="false" volatile="true" derived="true"
+	 * @see #setObjectKeys(int[])
+	 * @see org.eclipse.emf.henshin.statespace.StateSpacePackage#getModel_ObjectKeys()
+	 * @model dataType="org.eclipse.emf.henshin.statespace.IntegerArray" transient="true" volatile="true"
 	 * @generated
 	 */
 	int[] getObjectKeys();

--- a/plugins/org.eclipse.emf.henshin.statespace/src/org/eclipse/emf/henshin/statespace/StateSpace.java
+++ b/plugins/org.eclipse.emf.henshin.statespace/src/org/eclipse/emf/henshin/statespace/StateSpace.java
@@ -277,7 +277,7 @@ public interface StateSpace extends Storage {
 	 * Get the properties for this state space.
 	 * @return the value of the '<em>Properties</em>' map.
 	 * @see org.eclipse.emf.henshin.statespace.StateSpacePackage#getStateSpace_Properties()
-	 * @model mapType="org.eclipse.emf.ecore.EStringToStringMapEntry<org.eclipse.emf.ecore.EString, org.eclipse.emf.ecore.EString>"
+	 * @model mapType="org.eclipse.emf.ecore.EStringToStringMapEntry&lt;org.eclipse.emf.ecore.EString, org.eclipse.emf.ecore.EString&gt;"
 	 * @generated
 	 */
 	EMap<String, String> getProperties();

--- a/plugins/org.eclipse.emf.henshin.statespace/src/org/eclipse/emf/henshin/statespace/impl/ParallelStateSpaceManager.java
+++ b/plugins/org.eclipse.emf.henshin.statespace/src/org/eclipse/emf/henshin/statespace/impl/ParallelStateSpaceManager.java
@@ -20,6 +20,7 @@ import java.util.concurrent.Future;
 import org.eclipse.emf.henshin.statespace.State;
 import org.eclipse.emf.henshin.statespace.StateSpace;
 import org.eclipse.emf.henshin.statespace.StateSpaceException;
+import org.eclipse.emf.henshin.statespace.StateSpaceManager;
 
 /**
  * Parallelized {@link StateSpaceManager} implementation.

--- a/plugins/org.eclipse.emf.henshin.statespace/src/org/eclipse/emf/henshin/statespace/impl/StateExplorer.java
+++ b/plugins/org.eclipse.emf.henshin.statespace/src/org/eclipse/emf/henshin/statespace/impl/StateExplorer.java
@@ -39,6 +39,7 @@ import org.eclipse.emf.henshin.statespace.StateSpace;
 import org.eclipse.emf.henshin.statespace.StateSpaceException;
 import org.eclipse.emf.henshin.statespace.StateSpaceFactory;
 import org.eclipse.emf.henshin.statespace.StateSpaceIndex;
+import org.eclipse.emf.henshin.statespace.StateSpaceManager;
 import org.eclipse.emf.henshin.statespace.StateSpacePlugin;
 import org.eclipse.emf.henshin.statespace.StateValidator;
 import org.eclipse.emf.henshin.statespace.Transition;
@@ -347,7 +348,7 @@ public class StateExplorer {
 	/**
 	 * Check whether a state is a goal state.
 	 * @param state State to be checked.
-	 * @result <code>true</code> if it is a goal state.
+	 * @return <code>true</code> if it is a goal state.
 	 */
 	public boolean isGoalState(State state) throws StateSpaceException {
 		if (goalStateValidator==null) {

--- a/plugins/org.eclipse.emf.henshin.statespace/src/org/eclipse/emf/henshin/statespace/resource/StateSpaceDeserializer.java
+++ b/plugins/org.eclipse.emf.henshin.statespace/src/org/eclipse/emf/henshin/statespace/resource/StateSpaceDeserializer.java
@@ -36,8 +36,8 @@ public class StateSpaceDeserializer {
 	
 	/**
 	 * Deserialize a state space.
+	 * @param resource the State space resource.
 	 * @param in Input stream.
-	 * @result State space.
 	 * @throws IOException on I/O errors.
 	 */
 	public void read(StateSpaceResource resource, InputStream in) throws IOException {

--- a/plugins/org.eclipse.emf.henshin.tests/src/org/eclipse/emf/henshin/tests/framework/Matches.java
+++ b/plugins/org.eclipse.emf.henshin.tests/src/org/eclipse/emf/henshin/tests/framework/Matches.java
@@ -19,6 +19,8 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.henshin.interpreter.EGraph;
 import org.eclipse.emf.henshin.interpreter.Engine;
 import org.eclipse.emf.henshin.interpreter.Match;
+import org.eclipse.emf.henshin.interpreter.RuleApplication;
+import org.eclipse.emf.henshin.interpreter.UnitApplication;
 import org.eclipse.emf.henshin.interpreter.util.InterpreterUtil;
 import org.eclipse.emf.henshin.model.Rule;
 

--- a/plugins/org.eclipse.emf.henshin.tests/src/org/eclipse/emf/henshin/tests/framework/Rules.java
+++ b/plugins/org.eclipse.emf.henshin.tests/src/org/eclipse/emf/henshin/tests/framework/Rules.java
@@ -47,7 +47,7 @@ public class Rules {
 	 * Assert that a {@link Rule} has no match
 	 * 
 	 * @param rule {@link Rule}
-	 * @parem engine {@link Engine}
+	 * @param engine {@link Engine}
 	 * @throws AssertionError
 	 */
 	public static void assertRuleHasNoMatch(Rule rule, EGraph graph, Match partialMatch, Engine engine)
@@ -112,7 +112,7 @@ public class Rules {
 	 * @param graph {@link EGraph} the rule should be applied to
 	 * @param n Number of applications
 	 * @throws AssertionError
-	 * @throws Exception if n < 0
+	 * @throws Exception if {@code n < 0}
 	 */
 	public static void assertRuleCanBeAppliedNTimes(Rule r, EGraph graph, Engine engine, int n) throws AssertionError,
 			Exception {
@@ -128,7 +128,7 @@ public class Rules {
 	 * @param ra {@link RuleApplication}
 	 * @param n Number of applications
 	 * @throws AssertionError
-	 * @throws Exception if n < 0
+	 * @throws Exception if {@code n < 0}
 	 */
 	public static void assertRuleCanBeAppliedNTimes(RuleApplication ra, int n) throws AssertionError, Exception {
 		if (n < 0) {

--- a/plugins/org.eclipse.emf.henshin.text.tests/src/org/eclipse/emf/henshin/text/tests/TransformationTests.xtend
+++ b/plugins/org.eclipse.emf.henshin.text.tests/src/org/eclipse/emf/henshin/text/tests/TransformationTests.xtend
@@ -23,7 +23,7 @@ class TransformationTests {
 	@Inject extension ParseHelper<Model>
 	
 	/**
-	* T1: Test of nodes and edges with <preserve> action
+	* T1: Test of nodes and edges with {@code preserve} action
 	*/
 	@Test
 	def testPreserve(){
@@ -78,7 +78,7 @@ class TransformationTests {
 	 }
 
 	/**
-	* T2: Test of nodes and edges with <create> action
+	* T2: Test of nodes and edges with {@code create} action
 	*/
 	@Test
 	def testCreate(){
@@ -116,7 +116,7 @@ class TransformationTests {
 	
 	
 	/**
-	* T3: Test of nodes and edges with <delete> action
+	* T3: Test of nodes and edges with {@code delete} action
 	*/
 	@Test
 	def testDelete(){

--- a/plugins/org.eclipse.emf.henshin.text.tests/src/org/eclipse/emf/henshin/text/tests/formatting/TransformationFormattingTests.xtend
+++ b/plugins/org.eclipse.emf.henshin.text.tests/src/org/eclipse/emf/henshin/text/tests/formatting/TransformationFormattingTests.xtend
@@ -17,7 +17,7 @@ class TransformationFormattingTests {
 	@Inject extension FormatterTestHelper
 
 	/**
-	 * T1: Test of nodes and edges with <preserve> action
+	 * T1: Test of nodes and edges with {@code preserve} action
 	 */
 	@Test
 	def testPreserve() {
@@ -42,7 +42,7 @@ rule rulename() {
 	}
 
 	/**
-	 * T2: Test of nodes and edges with <create> action
+	 * T2: Test of nodes and edges with {@code create} action
 	 */
 	@Test
 	def testCreate() {
@@ -64,7 +64,7 @@ rule rulename() {
 	}
 
 	/**
-	 * T3: Test of nodes and edges with <delete> action
+	 * T3: Test of nodes and edges with {@code delete} action
 	 */
 	@Test
 	def testDelete() {

--- a/plugins/org.eclipse.emf.henshin.text/src-gen/org/eclipse/emf/henshin/text/serializer/Henshin_textSemanticSequencer.java
+++ b/plugins/org.eclipse.emf.henshin.text/src-gen/org/eclipse/emf/henshin/text/serializer/Henshin_textSemanticSequencer.java
@@ -632,7 +632,7 @@ public class Henshin_textSemanticSequencer extends AbstractDelegatingSemanticSeq
 	 *     ComparisonExpression.ComparisonExpression_1_0 returns ComparisonExpression
 	 *
 	 * Constraint:
-	 *     (left=ComparisonExpression_ComparisonExpression_1_0 (op='>=' | op='<=' | op='>' | op='<') right=PlusOrMinusExpression)
+	 *     (left=ComparisonExpression_ComparisonExpression_1_0 (op='&gt;=' | op='&lt;=' | op='&gt;' | op='&lt;') right=PlusOrMinusExpression)
 	 */
 	protected void sequence_ComparisonExpression(ISerializationContext context, ComparisonExpression semanticObject) {
 		genericSequencer.createSequence(context, semanticObject);

--- a/plugins/org.eclipse.emf.henshin.text/src/org/eclipse/emf/henshin/text/validation/Henshin_textValidator.xtend
+++ b/plugins/org.eclipse.emf.henshin.text/src/org/eclipse/emf/henshin/text/validation/Henshin_textValidator.xtend
@@ -774,7 +774,7 @@ class Henshin_textValidator extends AbstractHenshin_textValidator {
 	/**
  	* Fehler wenn ein forbid- oder require-Knoten in einer Kanten einer MultiRegel wiederverwendet werden soll
  	* 
- 	* @paran rule Zu überprüfende Regel
+ 	* @param rule Zu überprüfende Regel
  	*/
 	@Check
 	def checkEdgesInMultiRule(Rule rule){
@@ -797,7 +797,7 @@ class Henshin_textValidator extends AbstractHenshin_textValidator {
 	/**
  	* Fehler wenn ein Knoten mit ActionType require oder forbid reused wird
  	* 
- 	* @parameter multiReuseNode Zu überprüfender reuse-Node
+ 	* @param multiReuseNode Zu überprüfender reuse-Node
  	*/
 	@Check 
 	def checkMultiRuleReuseNodeActionType(MultiRuleReuseNode multiReuseNode){

--- a/plugins/variability/org.eclipse.emf.henshin.variability.configuration.ui/src/org/eclipse/emf/henshin/variability/ui/viewer/util/FeatureViewerContentProvider.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.configuration.ui/src/org/eclipse/emf/henshin/variability/ui/viewer/util/FeatureViewerContentProvider.java
@@ -4,6 +4,7 @@ import org.eclipse.jface.viewers.IStructuredContentProvider;
 import org.eclipse.jface.viewers.Viewer;
 
 import configuration.Configuration;
+import configuration.Feature;
 
 /**
  * Provides a {@link IStructuredContentProvider} for {@link Feature}s.

--- a/plugins/variability/org.eclipse.emf.henshin.variability.configuration.ui/src/org/eclipse/emf/henshin/variability/ui/views/VariabilityView.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.configuration.ui/src/org/eclipse/emf/henshin/variability/ui/views/VariabilityView.java
@@ -82,6 +82,7 @@ import org.eclipse.swt.widgets.Text;
 import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.ToolItem;
 import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IViewSite;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;

--- a/plugins/variability/org.eclipse.emf.henshin.variability.mergein.refactoring/src/org/eclipse/emf/henshin/variability/mergein/refactoring/popup/actions/MergeAction.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.mergein.refactoring/src/org/eclipse/emf/henshin/variability/mergein/refactoring/popup/actions/MergeAction.java
@@ -7,6 +7,7 @@ import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.IActionDelegate;
 import org.eclipse.ui.IObjectActionDelegate;
 import org.eclipse.ui.IWorkbenchPart;
 

--- a/plugins/variability/org.eclipse.emf.henshin.variability.mergein/src/org/eclipse/emf/henshin/variability/mergein/conqat/ConqatAttributeNode.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.mergein/src/org/eclipse/emf/henshin/variability/mergein/conqat/ConqatAttributeNode.java
@@ -1,5 +1,6 @@
 package org.eclipse.emf.henshin.variability.mergein.conqat;
 
+import org.conqat.engine.model_clones.model.IModelGraph;
 import org.conqat.engine.model_clones.model.INode;
 import org.eclipse.emf.henshin.variability.mergein.normalize.HenshinAttributeNode;
 

--- a/plugins/variability/org.eclipse.emf.henshin.variability.mergein/src/org/eclipse/emf/henshin/variability/mergein/conqat/ConqatEdge.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.mergein/src/org/eclipse/emf/henshin/variability/mergein/conqat/ConqatEdge.java
@@ -1,6 +1,7 @@
 package org.eclipse.emf.henshin.variability.mergein.conqat;
 
 import org.conqat.engine.model_clones.model.IDirectedEdge;
+import org.conqat.engine.model_clones.model.IModelGraph;
 import org.conqat.engine.model_clones.model.INode;
 import org.eclipse.emf.henshin.variability.mergein.normalize.HenshinEdge;
 

--- a/plugins/variability/org.eclipse.emf.henshin.variability.mergein/src/org/eclipse/emf/henshin/variability/mergein/conqat/ConqatNode.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.mergein/src/org/eclipse/emf/henshin/variability/mergein/conqat/ConqatNode.java
@@ -1,5 +1,6 @@
 package org.eclipse.emf.henshin.variability.mergein.conqat;
 
+import org.conqat.engine.model_clones.model.IModelGraph;
 import org.conqat.engine.model_clones.model.INode;
 import org.eclipse.emf.ecore.ENamedElement;
 import org.eclipse.emf.henshin.variability.mergein.normalize.HenshinNode;

--- a/plugins/variability/org.eclipse.emf.henshin.variability.test/tests/org/eclipse/emf/henshin/variability/tests/parameterized/VBEngineParameterizedTest.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.test/tests/org/eclipse/emf/henshin/variability/tests/parameterized/VBEngineParameterizedTest.java
@@ -21,6 +21,7 @@ import org.eclipse.emf.henshin.interpreter.RuleApplication;
 import org.eclipse.emf.henshin.interpreter.impl.EGraphImpl;
 import org.eclipse.emf.henshin.interpreter.impl.EngineImpl;
 import org.eclipse.emf.henshin.model.Rule;
+import org.eclipse.emf.henshin.variability.InconsistentRuleException;
 import org.eclipse.emf.henshin.variability.VarRuleApplicationImpl;
 import org.eclipse.emf.henshin.variability.matcher.VariabilityAwareMatch;
 import org.eclipse.emf.henshin.variability.matcher.VariabilityAwareMatcher;

--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,8 @@
 							<locale>en</locale>
 							<failOnError>false</failOnError>
 							<quiet>true</quiet>
+							<failOnError>true</failOnError>
+							<failOnWarnings>true</failOnWarnings>
 							<tags>
 								<!-- PDE API-tools javadoc annotations currently used -->
 								<tag>


### PR DESCRIPTION
This is a follow-up on
- https://github.com/eclipse-henshin/henshin/pull/26

and fixes all the remaining JavaDoc errors and warnings just outputted by the `maven-javadoc-plugin`.

This also adds back some imports in Java files that are only referenced in JavaDoc and were deleted too aggressively in
- https://github.com/eclipse-henshin/henshin/pull/30

In order to avoid all JavaDoc errors and warnings in the future, the `maven-javadoc-plugin` is also configured to fail the build on such warnings or errors.