### PR TITLE
Set explicit resource encoding for all projects to UTF-8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ plugins/*/xtend-gen/
 plugins/adapters/*/xtend-gen/
 
 # Ignore settings and metadata files
-.settings/
+**/.settings/*
+!**/.settings/org.eclipse.core.resources.prefs
 /.metadata/
 .DS_Store

--- a/doc/.settings/org.eclipse.core.resources.prefs
+++ b/doc/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/org.eclipse.emf.henshin.sdk.ocl2ac/.settings/org.eclipse.core.resources.prefs
+++ b/features/org.eclipse.emf.henshin.sdk.ocl2ac/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/org.eclipse.emf.henshin.sdk.variability/.settings/org.eclipse.core.resources.prefs
+++ b/features/org.eclipse.emf.henshin.sdk.variability/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/org.eclipse.emf.henshin.sdk/.settings/org.eclipse.core.resources.prefs
+++ b/features/org.eclipse.emf.henshin.sdk/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/p2updatesite/.settings/org.eclipse.core.resources.prefs
+++ b/p2updatesite/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/adapters/org.eclipse.emf.henshin.adapters.xtext/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/adapters/org.eclipse.emf.henshin.adapters.xtext/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/ocl2ac/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/ocl2ac/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.gc2ac/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.gc2ac/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model.edit/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model.edit/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model.editor/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model.editor/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.ocl2gc/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.ocl2gc/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.tool/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.utils/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.utils/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.emf.henshin.diagram/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.emf.henshin.diagram/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.emf.henshin.edit/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.emf.henshin.edit/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.emf.henshin.editor/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.emf.henshin.editor/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.emf.henshin.examples/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.emf.henshin.examples/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.emf.henshin.giraph/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.emf.henshin.giraph/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.emf.henshin.interpreter.ui/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.emf.henshin.interpreter.ui/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.emf.henshin.interpreter/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.emf.henshin.interpreter/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.emf.henshin.model/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.emf.henshin.model/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.emf.henshin.monitoring.kieker/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.emf.henshin.monitoring.kieker/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.emf.henshin.monitoring.ui/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.emf.henshin.monitoring.ui/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.emf.henshin.multicda.cda/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.emf.henshin.multicda.cda/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.emf.henshin.multicda.cpa.ui/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.emf.henshin.multicda.cpa.ui/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.emf.henshin.multicda.cpa/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.emf.henshin.multicda.cpa/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.emf.henshin.rulegen.tests/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.emf.henshin.rulegen.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.emf.henshin.rulegen.ui/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.emf.henshin.rulegen.ui/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.emf.henshin.rulegen/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.emf.henshin.rulegen/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.emf.henshin.statespace.explorer/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.emf.henshin.statespace.explorer/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.emf.henshin.statespace.external/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.emf.henshin.statespace.external/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.emf.henshin.statespace/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.emf.henshin.statespace/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.emf.henshin.tests/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.emf.henshin.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.emf.henshin.text.examples/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.emf.henshin.text.examples/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.emf.henshin.text.ide/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.emf.henshin.text.ide/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.emf.henshin.text.tests/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.emf.henshin.text.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.emf.henshin.text.transformation.tests/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.emf.henshin.text.transformation.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.emf.henshin.text.transformation/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.emf.henshin.text.transformation/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.emf.henshin.text.ui/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.emf.henshin.text.ui/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.emf.henshin.text/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.emf.henshin.text/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.emf.henshin.trace/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.emf.henshin.trace/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.emf.henshin.wrap/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/org.eclipse.emf.henshin.wrap/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/variability/org.eclipse.emf.henshin.variability.configuration.ui/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.configuration.ui/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/variability/org.eclipse.emf.henshin.variability.configuration/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.configuration/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/variability/org.eclipse.emf.henshin.variability.mergein.refactoring/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.mergein.refactoring/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/variability/org.eclipse.emf.henshin.variability.mergein.ui/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.mergein.ui/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/variability/org.eclipse.emf.henshin.variability.mergein/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.mergein/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/variability/org.eclipse.emf.henshin.variability.test/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.test/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/variability/org.eclipse.emf.henshin.variability/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/variability/org.eclipse.emf.henshin.variability/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/releng/org.eclipse.emf.henshin.target/.settings/org.eclipse.core.resources.prefs
+++ b/releng/org.eclipse.emf.henshin.target/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8


### PR DESCRIPTION
This fixes one warning per project (at least in the Eclipse workspace).