### PR TITLE
Fix raw type and unchecked type/invocation warnings

### DIFF
--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model.editor/src/graph/presentation/GraphEditor.java
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model.editor/src/graph/presentation/GraphEditor.java
@@ -1241,15 +1241,14 @@ public class GraphEditor extends MultiPageEditorPart
 	 * 
 	 * @generated
 	 */
-	@SuppressWarnings("rawtypes")
 	@Override
-	public Object getAdapter(Class key) {
+	public <T> T getAdapter(Class<T> key) {
 		if (key.equals(IContentOutlinePage.class)) {
-			return showOutlineView() ? getContentOutlinePage() : null;
-		} else if (key.equals(IPropertySheetPage.class)) {
-			return getPropertySheetPage();
-		} else if (key.equals(IGotoMarker.class)) {
-			return this;
+			return showOutlineView() ? key.cast(getContentOutlinePage()) : null;
+		} else if (key == IPropertySheetPage.class) {
+			return key.cast(getPropertySheetPage());
+		} else if (key == IGotoMarker.class) {
+			return key.cast(this);
 		} else {
 			return super.getAdapter(key);
 		}

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model.editor/src/laxcondition/presentation/LaxconditionEditor.java
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model.editor/src/laxcondition/presentation/LaxconditionEditor.java
@@ -1319,17 +1319,16 @@ public class LaxconditionEditor
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	@SuppressWarnings("rawtypes")
 	@Override
-	public Object getAdapter(Class key) {
-		if (key.equals(IContentOutlinePage.class)) {
-			return showOutlineView() ? getContentOutlinePage() : null;
+	public <T> T getAdapter(Class<T> key) {
+		if (key == IContentOutlinePage.class) {
+			return showOutlineView() ? key.cast(getContentOutlinePage()) : null;
 		}
-		else if (key.equals(IPropertySheetPage.class)) {
-			return getPropertySheetPage();
+		else if (key == IPropertySheetPage.class) {
+			return key.cast(getPropertySheetPage());
 		}
-		else if (key.equals(IGotoMarker.class)) {
-			return this;
+		else if (key == IGotoMarker.class) {
+			return key.cast(this);
 		}
 		else {
 			return super.getAdapter(key);

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model.editor/src/nestedcondition/presentation/NestedconditionEditor.java
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model.editor/src/nestedcondition/presentation/NestedconditionEditor.java
@@ -1319,17 +1319,16 @@ public class NestedconditionEditor
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	@SuppressWarnings("rawtypes")
 	@Override
-	public Object getAdapter(Class key) {
-		if (key.equals(IContentOutlinePage.class)) {
-			return showOutlineView() ? getContentOutlinePage() : null;
+	public <T> T getAdapter(Class<T> key) {
+		if (key == IContentOutlinePage.class) {
+			return showOutlineView() ? key.cast(getContentOutlinePage()) : null;
 		}
-		else if (key.equals(IPropertySheetPage.class)) {
-			return getPropertySheetPage();
+		else if (key == IPropertySheetPage.class) {
+			return key.cast(getPropertySheetPage());
 		}
-		else if (key.equals(IGotoMarker.class)) {
-			return this;
+		else if (key == IGotoMarker.class) {
+			return key.cast(this);
 		}
 		else {
 			return super.getAdapter(key);

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model.editor/src/nestedconstraintmodel/presentation/NestedconstraintmodelEditor.java
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.model.editor/src/nestedconstraintmodel/presentation/NestedconstraintmodelEditor.java
@@ -1317,17 +1317,16 @@ public class NestedconstraintmodelEditor
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	@SuppressWarnings("rawtypes")
 	@Override
-	public Object getAdapter(Class key) {
+	public <T> T getAdapter(Class<T> key) {
 		if (key.equals(IContentOutlinePage.class)) {
-			return showOutlineView() ? getContentOutlinePage() : null;
+			return showOutlineView() ? key.cast(getContentOutlinePage()) : null;
 		}
-		else if (key.equals(IPropertySheetPage.class)) {
-			return getPropertySheetPage();
+		else if (key == (IPropertySheetPage.class)) {
+			return key.cast(getPropertySheetPage());
 		}
-		else if (key.equals(IGotoMarker.class)) {
-			return this;
+		else if (key == (IGotoMarker.class)) {
+			return key.cast(this);
 		}
 		else {
 			return super.getAdapter(key);

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.utils/src/org/eclipse/emf/henshin/ocl2ac/utils/henshin/simplification/HenshinNACSimplifier.java
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.utils/src/org/eclipse/emf/henshin/ocl2ac/utils/henshin/simplification/HenshinNACSimplifier.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -30,7 +29,6 @@ import org.eclipse.emf.henshin.model.Not;
 import org.eclipse.emf.henshin.model.Or;
 import org.eclipse.emf.henshin.model.Rule;
 import org.eclipse.emf.henshin.model.UnaryFormula;
-
 import org.eclipse.emf.henshin.ocl2ac.utils.Activator;
 
 public class HenshinNACSimplifier {
@@ -488,7 +486,7 @@ public class HenshinNACSimplifier {
 	}
 
 	private static String getFullPath(String path) {
-		URL url = FileLocator.find(Activator.getDefault().getBundle(), new Path(path), Collections.EMPTY_MAP);
+		URL url = FileLocator.find(Activator.getDefault().getBundle(), new Path(path));
 		URL fileUrl = null;
 		try {
 			fileUrl = FileLocator.toFileURL(url);

--- a/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.utils/src/org/eclipse/emf/henshin/ocl2ac/utils/printer/CopyCommand.java
+++ b/plugins/ocl2ac/org.eclipse.emf.henshin.ocl2ac.utils/src/org/eclipse/emf/henshin/ocl2ac/utils/printer/CopyCommand.java
@@ -14,7 +14,6 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.Collections;
 
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IPath;
@@ -67,7 +66,7 @@ public class CopyCommand {
 	}
 
 	private static String getFullPath(IPath path) {
-		URL url = FileLocator.find(Activator.getDefault().getBundle(), path, Collections.emptyMap());
+		URL url = FileLocator.find(Activator.getDefault().getBundle(), path);
 		URL fileUrl = null;
 		try {
 			fileUrl = FileLocator.toFileURL(url);

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/parts/AttributeConditionBodyEditPart.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/parts/AttributeConditionBodyEditPart.java
@@ -523,6 +523,7 @@ public class AttributeConditionBodyEditPart extends CompartmentEditPart implemen
 	 * @generated
 	 */
 	@Override
+	@SuppressWarnings("rawtypes")
 	public Object getAdapter(Class key) {
 		if (ILabelDelegate.class.equals(key)) {
 			return getLabelDelegate();

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/parts/AttributeConditionNameEditPart.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/parts/AttributeConditionNameEditPart.java
@@ -527,6 +527,7 @@ public class AttributeConditionNameEditPart extends CompartmentEditPart implemen
 	 * @generated
 	 */
 	@Override
+	@SuppressWarnings("rawtypes")
 	public Object getAdapter(Class key) {
 		if (ILabelDelegate.class.equals(key)) {
 			return getLabelDelegate();

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/parts/AttributeEditPart.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/parts/AttributeEditPart.java
@@ -563,6 +563,7 @@ public class AttributeEditPart extends CompartmentEditPart implements ITextAware
 	 * @generated
 	 */
 	@Override
+	@SuppressWarnings("rawtypes")
 	public Object getAdapter(Class key) {
 		if (ILabelDelegate.class.equals(key)) {
 			return getLabelDelegate();

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/parts/EdgeActionEditPart.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/parts/EdgeActionEditPart.java
@@ -578,6 +578,7 @@ public class EdgeActionEditPart extends LabelEditPart implements ITextAwareEditP
 	 * @generated
 	 */
 	@Override
+	@SuppressWarnings("rawtypes")
 	public Object getAdapter(Class key) {
 		if (ILabelDelegate.class.equals(key)) {
 			return getLabelDelegate();

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/parts/EdgeTypeEditPart.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/parts/EdgeTypeEditPart.java
@@ -566,6 +566,7 @@ public class EdgeTypeEditPart extends LabelEditPart implements ITextAwareEditPar
 	 * @generated
 	 */
 	@Override
+	@SuppressWarnings("rawtypes")
 	public Object getAdapter(Class key) {
 		if (ILabelDelegate.class.equals(key)) {
 			return getLabelDelegate();

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/parts/InvocationNameEditPart.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/parts/InvocationNameEditPart.java
@@ -215,7 +215,7 @@ public class InvocationNameEditPart extends CompartmentEditPart implements IText
 		if (element != null) {
 			return new EObjectAdapter(element) {
 				@Override
-				public Object getAdapter(Class adapter) {
+				public Object getAdapter(@SuppressWarnings("rawtypes") Class adapter) {
 					if (View.class.equals(adapter)) {
 						return getNotationView();
 					}
@@ -563,7 +563,7 @@ public class InvocationNameEditPart extends CompartmentEditPart implements IText
 	 * @generated
 	 */
 	@Override
-	public Object getAdapter(Class key) {
+	public Object getAdapter(@SuppressWarnings("rawtypes") Class key) {
 		if (ILabelDelegate.class.equals(key)) {
 			return getLabelDelegate();
 		}

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/parts/NodeActionEditPart.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/parts/NodeActionEditPart.java
@@ -562,7 +562,7 @@ public class NodeActionEditPart extends CompartmentEditPart implements ITextAwar
 	 * @generated
 	 */
 	@Override
-	public Object getAdapter(Class key) {
+	public Object getAdapter(@SuppressWarnings("rawtypes") Class key) {
 		if (ILabelDelegate.class.equals(key)) {
 			return getLabelDelegate();
 		}

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/parts/NodeTypeEditPart.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/parts/NodeTypeEditPart.java
@@ -525,7 +525,7 @@ public class NodeTypeEditPart extends CompartmentEditPart implements ITextAwareE
 	 * @generated
 	 */
 	@Override
-	public Object getAdapter(Class key) {
+	public Object getAdapter(@SuppressWarnings("rawtypes") Class key) {
 		if (ILabelDelegate.class.equals(key)) {
 			return getLabelDelegate();
 		}

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/parts/RuleNameEditPart.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/parts/RuleNameEditPart.java
@@ -543,7 +543,7 @@ public class RuleNameEditPart extends CompartmentEditPart implements ITextAwareE
 	 * @generated
 	 */
 	@Override
-	public Object getAdapter(Class key) {
+	public Object getAdapter(@SuppressWarnings("rawtypes") Class key) {
 		if (ILabelDelegate.class.equals(key)) {
 			return getLabelDelegate();
 		}

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/parts/UnitNameEditPart.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/parts/UnitNameEditPart.java
@@ -543,7 +543,7 @@ public class UnitNameEditPart extends CompartmentEditPart implements ITextAwareE
 	 * @generated
 	 */
 	@Override
-	public Object getAdapter(Class key) {
+	public Object getAdapter(@SuppressWarnings("rawtypes") Class key) {
 		if (ILabelDelegate.class.equals(key)) {
 			return getLabelDelegate();
 		}

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/policies/HenshinBaseItemSemanticEditPolicy.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/policies/HenshinBaseItemSemanticEditPolicy.java
@@ -9,7 +9,8 @@
  */
 package org.eclipse.emf.henshin.diagram.edit.policies;
 
-import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 import org.eclipse.emf.henshin.diagram.part.HenshinDiagramEditorPlugin;
 import org.eclipse.emf.henshin.diagram.part.HenshinVisualIDRegistry;
@@ -84,7 +85,9 @@ public class HenshinBaseItemSemanticEditPolicy extends SemanticEditPolicy {
 			Object view = ((ReconnectRequest) request).getConnectionEditPart().getModel();
 			if (view instanceof View) {
 				Integer id = new Integer(HenshinVisualIDRegistry.getVisualID((View) view));
-				request.getExtendedData().put(VISUAL_ID_KEY, id);
+				@SuppressWarnings("unchecked")
+				Map<String, Object> extendedData = request.getExtendedData();
+				extendedData.put(VISUAL_ID_KEY, id);
 			}
 		}
 		return super.getCommand(request);
@@ -280,13 +283,14 @@ public class HenshinBaseItemSemanticEditPolicy extends SemanticEditPolicy {
 	 */
 	protected void addDestroyShortcutsCommand(ICompositeCommand cmd, View view) {
 		assert view.getEAnnotation("Shortcut") == null; //$NON-NLS-1$
-		for (Iterator it = view.getDiagram().getChildren().iterator(); it.hasNext();) {
-			View nextView = (View) it.next();
-			if (nextView.getEAnnotation("Shortcut") == null || !nextView.isSetElement() //$NON-NLS-1$
-					|| nextView.getElement() != view.getElement()) {
+		@SuppressWarnings("unchecked")
+		List<View> children = view.getDiagram().getChildren();
+		for (View child : children) {
+			if (child.getEAnnotation("Shortcut") == null || !child.isSetElement() //$NON-NLS-1$
+					|| child.getElement() != view.getElement()) {
 				continue;
 			}
-			cmd.add(new DeleteCommand(getEditingDomain(), nextView));
+			cmd.add(new DeleteCommand(getEditingDomain(), child));
 		}
 	}
 

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/policies/HenshinTextNonResizableEditPolicy.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/policies/HenshinTextNonResizableEditPolicy.java
@@ -225,7 +225,7 @@ public class HenshinTextNonResizableEditPolicy extends NonResizableEditPolicyEx
 	/**
 	 * @generated
 	 */
-	protected List createSelectionHandles() {
+	protected List<MoveHandle> createSelectionHandles() {
 		MoveHandle moveHandle = new MoveHandle((GraphicalEditPart) getHost());
 		moveHandle.setBorder(null);
 		moveHandle.setDragTracker(new DragEditPartsTrackerEx(getHost()));

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/policies/ModuleCanonicalEditPolicy.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/policies/ModuleCanonicalEditPolicy.java
@@ -263,8 +263,9 @@ public class ModuleCanonicalEditPolicy extends CanonicalEditPolicy {
 	private Collection<IAdaptable> refreshConnections() {
 		Domain2Notation domain2NotationMap = new Domain2Notation();
 		Collection<HenshinLinkDescriptor> linkDescriptors = collectAllLinks(getDiagram(), domain2NotationMap);
-		Collection existingLinks = new LinkedList(getDiagram().getEdges());
-		for (Iterator linksIterator = existingLinks.iterator(); linksIterator.hasNext();) {
+		@SuppressWarnings("unchecked")
+		List<View> existingLinks = new ArrayList<>(getDiagram().getEdges());
+		for (Iterator<View> linksIterator = existingLinks.iterator(); linksIterator.hasNext();) {
 			Edge nextDiagramLink = (Edge) linksIterator.next();
 			int diagramLinkVisualID = HenshinVisualIDRegistry.getVisualID(nextDiagramLink);
 			if (diagramLinkVisualID == -1 || diagramLinkVisualID == LinkEditPart.VISUAL_ID) {
@@ -352,11 +353,15 @@ public class ModuleCanonicalEditPolicy extends CanonicalEditPolicy {
 			break;
 		}
 		}
-		for (Iterator children = view.getChildren().iterator(); children.hasNext();) {
-			result.addAll(collectAllLinks((View) children.next(), domain2NotationMap));
+		@SuppressWarnings("unchecked")
+		List<View> children = view.getChildren();
+		for (View child : children) {
+			result.addAll(collectAllLinks(child, domain2NotationMap));
 		}
-		for (Iterator edges = view.getSourceEdges().iterator(); edges.hasNext();) {
-			result.addAll(collectAllLinks((View) edges.next(), domain2NotationMap));
+		@SuppressWarnings("unchecked")
+		List<View> sourceEdges = view.getSourceEdges();
+		for (View sourceEdge : sourceEdges) {
+			result.addAll(collectAllLinks(sourceEdge, domain2NotationMap));
 		}
 		return result;
 	}

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/policies/NodeGraphicalEditPolicy.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/policies/NodeGraphicalEditPolicy.java
@@ -95,7 +95,7 @@ public class NodeGraphicalEditPolicy extends GraphicalNodeEditPolicy {
 	 */
 	@Override
 	@SuppressWarnings("unchecked")
-	protected ICommand getPromptAndCreateConnectionCommand(List content, CreateConnectionRequest request) {
+	protected ICommand getPromptAndCreateConnectionCommand(@SuppressWarnings("rawtypes") List content, CreateConnectionRequest request) {
 		return new PromptAndCreateEdgeCommand(content, request);
 	}
 	

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/policies/RuleCompartmentCanonicalEditPolicy.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/edit/policies/RuleCompartmentCanonicalEditPolicy.java
@@ -65,9 +65,9 @@ public class RuleCompartmentCanonicalEditPolicy extends CanonicalEditPolicy {
 	/**
 	 * @generated
 	 */
-	protected Set getFeaturesToSynchronize() {
+	protected Set<EStructuralFeature> getFeaturesToSynchronize() {
 		if (myFeaturesToSynchronize == null) {
-			myFeaturesToSynchronize = new HashSet<EStructuralFeature>();
+			myFeaturesToSynchronize = new HashSet<>();
 			myFeaturesToSynchronize.add(HenshinPackage.eINSTANCE.getGraph_Nodes());
 			myFeaturesToSynchronize.add(HenshinPackage.eINSTANCE.getRule_AttributeConditions());
 		}

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/navigator/HenshinAbstractNavigatorItem.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/navigator/HenshinAbstractNavigatorItem.java
@@ -23,23 +23,24 @@ public abstract class HenshinAbstractNavigatorItem extends PlatformObject {
 	 * @generated
 	 */
 	static {
-		final Class[] supportedTypes = new Class[] { ITabbedPropertySheetPageContributor.class };
+		final Class<?>[] supportedTypes = new Class<?>[] { ITabbedPropertySheetPageContributor.class };
 		final ITabbedPropertySheetPageContributor propertySheetPageContributor = new ITabbedPropertySheetPageContributor() {
 			public String getContributorId() {
 				return "org.eclipse.emf.henshin.diagram"; //$NON-NLS-1$
 			}
 		};
 		Platform.getAdapterManager().registerAdapters(new IAdapterFactory() {
-
-			public Object getAdapter(Object adaptableObject, Class adapterType) {
+			@Override
+			public <T> T getAdapter(Object adaptableObject, Class<T> adapterType) {
 				if (adaptableObject instanceof org.eclipse.emf.henshin.diagram.navigator.HenshinAbstractNavigatorItem
 						&& adapterType == ITabbedPropertySheetPageContributor.class) {
-					return propertySheetPageContributor;
+					return adapterType.cast(propertySheetPageContributor);
 				}
 				return null;
 			}
 
-			public Class[] getAdapterList() {
+			@Override
+			public Class<?>[] getAdapterList() {
 				return supportedTypes;
 			}
 		}, org.eclipse.emf.henshin.diagram.navigator.HenshinAbstractNavigatorItem.class);

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/navigator/HenshinDomainNavigatorContentProvider.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/navigator/HenshinDomainNavigatorContentProvider.java
@@ -195,11 +195,11 @@ public class HenshinDomainNavigatorContentProvider implements ICommonContentProv
 	 * @generated
 	 */
 	public Object[] wrapEObjects(Object[] objects, Object parentElement) {
-		Collection result = new ArrayList();
-		for (int i = 0; i < objects.length; i++) {
-			if (objects[i] instanceof EObject) {
-				result.add(new HenshinDomainNavigatorItem((EObject) objects[i], parentElement,
-						myAdapterFctoryContentProvier));
+		Collection<HenshinDomainNavigatorItem> result = new ArrayList<>();
+		for (Object object : objects) {
+			if (object instanceof EObject) {
+				EObject eObject = (EObject) object;
+				result.add(new HenshinDomainNavigatorItem(eObject, parentElement, myAdapterFctoryContentProvier));
 			}
 		}
 		return result.toArray();

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/navigator/HenshinDomainNavigatorItem.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/navigator/HenshinDomainNavigatorItem.java
@@ -26,25 +26,25 @@ public class HenshinDomainNavigatorItem extends PlatformObject {
 	 * @generated
 	 */
 	static {
-		final Class[] supportedTypes = new Class[] { EObject.class, IPropertySource.class };
+		final Class<?>[] supportedTypes = new Class<?>[] { EObject.class, IPropertySource.class };
 		Platform.getAdapterManager().registerAdapters(new IAdapterFactory() {
-
-			public Object getAdapter(Object adaptableObject, Class adapterType) {
+			@Override
+			public <T> T getAdapter(Object adaptableObject, Class<T> adapterType) {
 				if (adaptableObject instanceof org.eclipse.emf.henshin.diagram.navigator.HenshinDomainNavigatorItem) {
 					org.eclipse.emf.henshin.diagram.navigator.HenshinDomainNavigatorItem domainNavigatorItem = (org.eclipse.emf.henshin.diagram.navigator.HenshinDomainNavigatorItem) adaptableObject;
 					EObject eObject = domainNavigatorItem.getEObject();
 					if (adapterType == EObject.class) {
-						return eObject;
+						return adapterType.cast(eObject);
 					}
 					if (adapterType == IPropertySource.class) {
-						return domainNavigatorItem.getPropertySourceProvider().getPropertySource(eObject);
+						return adapterType.cast(domainNavigatorItem.getPropertySourceProvider().getPropertySource(eObject));
 					}
 				}
-
 				return null;
 			}
 
-			public Class[] getAdapterList() {
+			@Override
+			public Class<?>[] getAdapterList() {
 				return supportedTypes;
 			}
 		}, org.eclipse.emf.henshin.diagram.navigator.HenshinDomainNavigatorItem.class);

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/navigator/HenshinNavigatorContentProvider.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/navigator/HenshinNavigatorContentProvider.java
@@ -572,6 +572,7 @@ public class HenshinNavigatorContentProvider implements ICommonContentProvider {
 	/**
 	 * @generated
 	 */
+	@SuppressWarnings("unchecked")
 	private Collection<View> getOutgoingLinksByType(Collection<? extends View> nodes, String type) {
 		LinkedList<View> result = new LinkedList<View>();
 		for (View nextNode : nodes) {
@@ -583,6 +584,7 @@ public class HenshinNavigatorContentProvider implements ICommonContentProvider {
 	/**
 	 * @generated
 	 */
+	@SuppressWarnings("unchecked")
 	private Collection<View> getIncomingLinksByType(Collection<? extends View> nodes, String type) {
 		LinkedList<View> result = new LinkedList<View>();
 		for (View nextNode : nodes) {
@@ -594,6 +596,7 @@ public class HenshinNavigatorContentProvider implements ICommonContentProvider {
 	/**
 	 * @generated
 	 */
+	@SuppressWarnings("unchecked")
 	private Collection<View> getChildrenByType(Collection<? extends View> nodes, String type) {
 		LinkedList<View> result = new LinkedList<View>();
 		for (View nextNode : nodes) {
@@ -605,6 +608,7 @@ public class HenshinNavigatorContentProvider implements ICommonContentProvider {
 	/**
 	 * @generated
 	 */
+	@SuppressWarnings("unchecked")
 	private Collection<View> getDiagramLinksByType(Collection<Diagram> diagrams, String type) {
 		ArrayList<View> result = new ArrayList<View>();
 		for (Diagram nextDiagram : diagrams) {

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/navigator/HenshinNavigatorGroup.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/navigator/HenshinNavigatorGroup.java
@@ -9,8 +9,8 @@
  */
 package org.eclipse.emf.henshin.diagram.navigator;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 
 /**
  * @generated
@@ -30,7 +30,7 @@ public class HenshinNavigatorGroup extends HenshinAbstractNavigatorItem {
 	/**
 	 * @generated
 	 */
-	private Collection myChildren = new LinkedList();
+	private Collection<HenshinNavigatorItem> myChildren = new ArrayList<>();
 
 	/**
 	 * @generated
@@ -65,14 +65,14 @@ public class HenshinNavigatorGroup extends HenshinAbstractNavigatorItem {
 	/**
 	 * @generated
 	 */
-	public void addChildren(Collection children) {
+	public void addChildren(Collection<HenshinNavigatorItem> children) {
 		myChildren.addAll(children);
 	}
 
 	/**
 	 * @generated
 	 */
-	public void addChild(Object child) {
+	public void addChild(HenshinNavigatorItem child) {
 		myChildren.add(child);
 	}
 
@@ -80,7 +80,7 @@ public class HenshinNavigatorGroup extends HenshinAbstractNavigatorItem {
 	 * @generated
 	 */
 	public boolean isEmpty() {
-		return myChildren.size() == 0;
+		return myChildren.isEmpty();
 	}
 
 	/**

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/navigator/HenshinNavigatorItem.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/navigator/HenshinNavigatorItem.java
@@ -24,18 +24,19 @@ public class HenshinNavigatorItem extends HenshinAbstractNavigatorItem {
 	 * @generated
 	 */
 	static {
-		final Class[] supportedTypes = new Class[] { View.class, EObject.class };
+		final Class<?>[] supportedTypes = new Class<?>[] { View.class, EObject.class };
 		Platform.getAdapterManager().registerAdapters(new IAdapterFactory() {
-
-			public Object getAdapter(Object adaptableObject, Class adapterType) {
+			@Override
+			public <T> T getAdapter(Object adaptableObject, Class<T> adapterType) {
 				if (adaptableObject instanceof org.eclipse.emf.henshin.diagram.navigator.HenshinNavigatorItem
 						&& (adapterType == View.class || adapterType == EObject.class)) {
-					return ((org.eclipse.emf.henshin.diagram.navigator.HenshinNavigatorItem) adaptableObject).getView();
+					return adapterType.cast(((HenshinNavigatorItem) adaptableObject).getView());
 				}
 				return null;
 			}
 
-			public Class[] getAdapterList() {
+			@Override
+			public Class<?>[] getAdapterList() {
 				return supportedTypes;
 			}
 		}, org.eclipse.emf.henshin.diagram.navigator.HenshinNavigatorItem.class);

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/part/HenshinDiagramActionBarContributor.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/part/HenshinDiagramActionBarContributor.java
@@ -25,7 +25,7 @@ public class HenshinDiagramActionBarContributor extends DiagramActionBarContribu
 	/**
 	 * @generated
 	 */
-	protected Class getEditorClass() {
+	protected Class<HenshinDiagramEditor> getEditorClass() {
 		return HenshinDiagramEditor.class;
 	}
 

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/part/HenshinDiagramUpdateCommand.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/part/HenshinDiagramUpdateCommand.java
@@ -9,7 +9,6 @@
  */
 package org.eclipse.emf.henshin.diagram.part;
 
-import java.util.Iterator;
 import java.util.List;
 
 import org.eclipse.core.commands.ExecutionEvent;
@@ -56,9 +55,8 @@ public class HenshinDiagramUpdateCommand implements IHandler {
 					&& ((EditPart) structuredSelection.getFirstElement()).getModel() instanceof View) {
 				EObject modelElement = ((View) ((EditPart) structuredSelection.getFirstElement()).getModel())
 						.getElement();
-				List editPolicies = CanonicalEditPolicy.getRegisteredEditPolicies(modelElement);
-				for (Iterator it = editPolicies.iterator(); it.hasNext();) {
-					CanonicalEditPolicy nextEditPolicy = (CanonicalEditPolicy) it.next();
+				List<CanonicalEditPolicy> editPolicies = CanonicalEditPolicy.getRegisteredEditPolicies(modelElement);
+				for (CanonicalEditPolicy nextEditPolicy : editPolicies) {
 					nextEditPolicy.refresh();
 				}
 

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/part/HenshinDocumentProvider.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/part/HenshinDocumentProvider.java
@@ -206,7 +206,8 @@ public class HenshinDocumentProvider extends AbstractDocumentProvider implements
 				}
 				if (!resource.isLoaded()) {
 					try {
-						Map options = new HashMap(GMFResourceFactory.getDefaultLoadOptions());
+						@SuppressWarnings("unchecked")
+						Map<?, ?> options = new HashMap<>(GMFResourceFactory.getDefaultLoadOptions());
 						// @see 171060 
 						// options.put(org.eclipse.emf.ecore.xmi.XMLResource.OPTION_RECORD_UNKNOWN_FEATURE, Boolean.TRUE);
 						resource.load(options);
@@ -222,8 +223,7 @@ public class HenshinDocumentProvider extends AbstractDocumentProvider implements
 						return;
 					}
 				} else {
-					for (Iterator it = resource.getContents().iterator(); it.hasNext();) {
-						Object rootElement = it.next();
+					for (EObject rootElement : resource.getContents()) {
 						if (rootElement instanceof Diagram) {
 							document.setContent((Diagram) rootElement);
 							return;
@@ -985,9 +985,8 @@ public class HenshinDocumentProvider extends AbstractDocumentProvider implements
 					Resource resource = (Resource) notification.getNotifier();
 					if (resource.isLoaded()) {
 						boolean modified = false;
-						for (Iterator /*<org.eclipse.emf.ecore.resource.Resource>*/ it = myInfo
-								.getLoadedResourcesIterator(); it.hasNext() && !modified;) {
-							Resource nextResource = (Resource) it.next();
+						for (Iterator<Resource> it = myInfo.getLoadedResourcesIterator(); it.hasNext() && !modified;) {
+							Resource nextResource = it.next();
 							if (nextResource.isLoaded()) {
 								modified = nextResource.isModified();
 							}

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/providers/HenshinMarkerNavigationProvider.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/providers/HenshinMarkerNavigationProvider.java
@@ -42,12 +42,13 @@ public class HenshinMarkerNavigationProvider extends AbstractModelMarkerNavigati
 			return;
 		}
 		DiagramEditor editor = (DiagramEditor) getEditor();
-		Map editPartRegistry = editor.getDiagramGraphicalViewer().getEditPartRegistry();
+		@SuppressWarnings("unchecked")
+		Map<EObject, EditPart> editPartRegistry = editor.getDiagramGraphicalViewer().getEditPartRegistry();
 		EObject targetView = editor.getDiagram().eResource().getEObject(elementId);
 		if (targetView == null) {
 			return;
 		}
-		EditPart targetEditPart = (EditPart) editPartRegistry.get(targetView);
+		EditPart targetEditPart = editPartRegistry.get(targetView);
 		if (targetEditPart != null) {
 			HenshinDiagramEditorUtil.selectElementsInDiagram(editor, Arrays.asList(new EditPart[] { targetEditPart }));
 		}

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/providers/HenshinModelingAssistantProvider.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/providers/HenshinModelingAssistantProvider.java
@@ -11,7 +11,8 @@ package org.eclipse.emf.henshin.diagram.providers;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Iterator;
+import java.util.Set;
+
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.edit.ui.provider.AdapterFactoryLabelProvider;
@@ -36,6 +37,7 @@ public class HenshinModelingAssistantProvider extends ModelingAssistantProvider 
 	/**
 	 * @generated
 	 */
+	@SuppressWarnings("unchecked")
 	public EObject selectExistingElementForSource(IAdaptable target, IElementType relationshipType) {
 		return selectExistingElement(target, getTypesForSource(target, relationshipType));
 	}
@@ -43,6 +45,7 @@ public class HenshinModelingAssistantProvider extends ModelingAssistantProvider 
 	/**
 	 * @generated
 	 */
+	@SuppressWarnings("unchecked")
 	public EObject selectExistingElementForTarget(IAdaptable source, IElementType relationshipType) {
 		return selectExistingElement(source, getTypesForTarget(source, relationshipType));
 	}
@@ -50,7 +53,7 @@ public class HenshinModelingAssistantProvider extends ModelingAssistantProvider 
 	/**
 	 * @generated
 	 */
-	protected EObject selectExistingElement(IAdaptable host, Collection types) {
+	protected EObject selectExistingElement(IAdaptable host, Collection<IElementType> types) {
 		if (types.isEmpty()) {
 			return null;
 		}
@@ -59,23 +62,22 @@ public class HenshinModelingAssistantProvider extends ModelingAssistantProvider 
 			return null;
 		}
 		Diagram diagram = (Diagram) editPart.getRoot().getContents().getModel();
-		HashSet<EObject> elements = new HashSet<EObject>();
-		for (Iterator<EObject> it = diagram.getElement().eAllContents(); it.hasNext();) {
-			EObject element = it.next();
+		Set<EObject> elements = new HashSet<>();
+		diagram.getElement().eAllContents().forEachRemaining(element -> {
 			if (isApplicableElement(element, types)) {
 				elements.add(element);
 			}
-		}
+		});
 		if (elements.isEmpty()) {
 			return null;
 		}
-		return selectElement((EObject[]) elements.toArray(new EObject[elements.size()]));
+		return selectElement(elements.toArray(EObject[]::new));
 	}
 
 	/**
 	 * @generated
 	 */
-	protected boolean isApplicableElement(EObject element, Collection types) {
+	protected boolean isApplicableElement(EObject element, Collection<IElementType> types) {
 		IElementType type = ElementTypeRegistry.getInstance().getElementType(element);
 		return types.contains(type);
 	}

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/providers/HenshinParserProvider.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/providers/HenshinParserProvider.java
@@ -249,7 +249,7 @@ public class HenshinParserProvider extends AbstractProvider implements IParserPr
 		/**
 		 * @generated
 		 */
-		public Object getAdapter(Class adapter) {
+		public Object getAdapter(@SuppressWarnings("rawtypes") Class adapter) {
 			if (IElementType.class.equals(adapter)) {
 				return elementType;
 			}

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/providers/HenshinValidationDecoratorProvider.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/providers/HenshinValidationDecoratorProvider.java
@@ -11,7 +11,6 @@ package org.eclipse.emf.henshin.diagram.providers;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -73,7 +72,7 @@ public class HenshinValidationDecoratorProvider extends AbstractProvider impleme
 	/**
 	 * @generated
 	 */
-	private static Map/*<String, List<IDecorator>>*/ allDecorators = new HashMap();
+	private static final Map<String, List<IDecorator>> ALL_DECORATORS = new HashMap<>();
 
 	/**
 	 * @generated
@@ -121,20 +120,19 @@ public class HenshinValidationDecoratorProvider extends AbstractProvider impleme
 	 * @generated
 	 */
 	private static void refreshDecorators(String viewId, Diagram diagram) {
-		final List decorators = viewId != null ? (List) allDecorators.get(viewId) : null;
+		final List<IDecorator> decorators = viewId != null ? ALL_DECORATORS.get(viewId) : null;
 		if (decorators == null || decorators.isEmpty() || diagram == null) {
 			return;
 		}
 		final Diagram fdiagram = diagram;
 		PlatformUI.getWorkbench().getDisplay().asyncExec(new Runnable() {
-
+			@Override
 			public void run() {
 				try {
 					TransactionUtil.getEditingDomain(fdiagram).runExclusive(new Runnable() {
-
+						@Override
 						public void run() {
-							for (Iterator it = decorators.iterator(); it.hasNext();) {
-								IDecorator decorator = (IDecorator) it.next();
+							for (IDecorator decorator : decorators) {
 								decorator.refresh();
 							}
 						}
@@ -283,12 +281,8 @@ public class HenshinValidationDecoratorProvider extends AbstractProvider impleme
 			}
 
 			// add self to global decorators registry
-			List list = (List) allDecorators.get(viewId);
-			if (list == null) {
-				list = new ArrayList(2);
-				list.add(this);
-				allDecorators.put(viewId, list);
-			} else if (!list.contains(this)) {
+			List<IDecorator> list = ALL_DECORATORS.computeIfAbsent(viewId, id -> new ArrayList<>(2));
+			if (!list.contains(this)) {
 				list.add(this);
 			}
 
@@ -315,16 +309,16 @@ public class HenshinValidationDecoratorProvider extends AbstractProvider impleme
 			}
 
 			// remove self from global decorators registry
-			List list = (List) allDecorators.get(viewId);
+			List<IDecorator> list = ALL_DECORATORS.get(viewId);
 			if (list != null) {
 				list.remove(this);
 				if (list.isEmpty()) {
-					allDecorators.remove(viewId);
+					ALL_DECORATORS.remove(viewId);
 				}
 			}
 
 			// stop listening to changes in resources if there are no more decorators
-			if (fileObserver != null && allDecorators.isEmpty()) {
+			if (fileObserver != null && ALL_DECORATORS.isEmpty()) {
 				FileChangeManager.getInstance().removeFileObserver(fileObserver);
 				fileObserver = null;
 			}
@@ -385,7 +379,7 @@ public class HenshinValidationDecoratorProvider extends AbstractProvider impleme
 		/**
 		 * @generated
 		 */
-		public void handleMarkerDeleted(IMarker marker, Map attributes) {
+		public void handleMarkerDeleted(IMarker marker, @SuppressWarnings("rawtypes") Map attributes) {
 			String viewId = (String) attributes.get(org.eclipse.gmf.runtime.common.ui.resources.IMarker.ELEMENT_ID);
 			refreshDecorators(viewId, diagram);
 		}

--- a/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/providers/HenshinViewProvider.java
+++ b/plugins/org.eclipse.emf.henshin.diagram/src/org/eclipse/emf/henshin/diagram/providers/HenshinViewProvider.java
@@ -10,6 +10,7 @@
 package org.eclipse.emf.henshin.diagram.providers;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.draw2d.ColorConstants;
@@ -211,7 +212,7 @@ public class HenshinViewProvider extends AbstractProvider implements IViewProvid
 	 */
 	public Diagram createDiagram(IAdaptable semanticAdapter, String diagramKind, PreferencesHint preferencesHint) {
 		Diagram diagram = NotationFactory.eINSTANCE.createDiagram();
-		diagram.getStyles().add(NotationFactory.eINSTANCE.createDiagramStyle());
+		getStyles(diagram).add(NotationFactory.eINSTANCE.createDiagramStyle());
 		diagram.setType(ModuleEditPart.MODEL_ID);
 		diagram.setElement(getSemanticElement(semanticAdapter));
 		diagram.setMeasurementUnit(MeasurementUnit.PIXEL_LITERAL);
@@ -465,8 +466,8 @@ public class HenshinViewProvider extends AbstractProvider implements IViewProvid
 	public Node createAttributeCondition_3005(EObject domainElement, View containerView, int index, boolean persisted,
 			PreferencesHint preferencesHint) {
 		Node node = NotationFactory.eINSTANCE.createNode();
-		node.getStyles().add(NotationFactory.eINSTANCE.createDescriptionStyle());
-		node.getStyles().add(NotationFactory.eINSTANCE.createFontStyle());
+		getStyles(node).add(NotationFactory.eINSTANCE.createDescriptionStyle());
+		getStyles(node).add(NotationFactory.eINSTANCE.createFontStyle());
 		node.setLayoutConstraint(NotationFactory.eINSTANCE.createBounds());
 		node.setType(HenshinVisualIDRegistry.getType(AttributeConditionEditPart.VISUAL_ID));
 		ViewUtil.insertChildView(containerView, node, index, persisted);
@@ -495,8 +496,8 @@ public class HenshinViewProvider extends AbstractProvider implements IViewProvid
 	public Node createNode_3004(EObject domainElement, View containerView, int index, boolean persisted,
 			PreferencesHint preferencesHint) {
 		Node node = NotationFactory.eINSTANCE.createNode();
-		node.getStyles().add(NotationFactory.eINSTANCE.createDescriptionStyle());
-		node.getStyles().add(NotationFactory.eINSTANCE.createFontStyle());
+		getStyles(node).add(NotationFactory.eINSTANCE.createDescriptionStyle());
+		getStyles(node).add(NotationFactory.eINSTANCE.createFontStyle());
 		node.setLayoutConstraint(NotationFactory.eINSTANCE.createBounds());
 		node.setType(HenshinVisualIDRegistry.getType(SymbolEditPart.VISUAL_ID));
 		ViewUtil.insertChildView(containerView, node, index, persisted);
@@ -577,7 +578,7 @@ public class HenshinViewProvider extends AbstractProvider implements IViewProvid
 	public Edge createEdge_4001(EObject domainElement, View containerView, int index, boolean persisted,
 			PreferencesHint preferencesHint) {
 		Connector edge = NotationFactory.eINSTANCE.createConnector();
-		edge.getStyles().add(NotationFactory.eINSTANCE.createFontStyle());
+		getStyles(edge).add(NotationFactory.eINSTANCE.createFontStyle());
 		RelativeBendpoints bendpoints = NotationFactory.eINSTANCE.createRelativeBendpoints();
 		ArrayList<RelativeBendpoint> points = new ArrayList<RelativeBendpoint>(2);
 		points.add(new RelativeBendpoint());
@@ -627,8 +628,8 @@ public class HenshinViewProvider extends AbstractProvider implements IViewProvid
 	 */
 	public Edge createLink_4002(View containerView, int index, boolean persisted, PreferencesHint preferencesHint) {
 		Edge edge = NotationFactory.eINSTANCE.createEdge();
-		edge.getStyles().add(NotationFactory.eINSTANCE.createRoutingStyle());
-		edge.getStyles().add(NotationFactory.eINSTANCE.createFontStyle());
+		getStyles(edge).add(NotationFactory.eINSTANCE.createRoutingStyle());
+		getStyles(edge).add(NotationFactory.eINSTANCE.createFontStyle());
 		RelativeBendpoints bendpoints = NotationFactory.eINSTANCE.createRelativeBendpoints();
 		ArrayList<RelativeBendpoint> points = new ArrayList<RelativeBendpoint>(2);
 		points.add(new RelativeBendpoint());
@@ -697,17 +698,22 @@ public class HenshinViewProvider extends AbstractProvider implements IViewProvid
 		if (hasTitle) {
 			TitleStyle ts = NotationFactory.eINSTANCE.createTitleStyle();
 			ts.setShowTitle(true);
-			rv.getStyles().add(ts);
+			getStyles(rv).add(ts);
 		}
 		if (canSort) {
-			rv.getStyles().add(NotationFactory.eINSTANCE.createSortingStyle());
+			getStyles(rv).add(NotationFactory.eINSTANCE.createSortingStyle());
 		}
 		if (canFilter) {
-			rv.getStyles().add(NotationFactory.eINSTANCE.createFilteringStyle());
+			getStyles(rv).add(NotationFactory.eINSTANCE.createFilteringStyle());
 		}
 		rv.setType(hint);
 		ViewUtil.insertChildView(owner, rv, ViewUtil.APPEND, true);
 		return rv;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static List<org.eclipse.gmf.runtime.notation.Style> getStyles(View view) {
+		return view.getStyles();
 	}
 
 	/**

--- a/plugins/org.eclipse.emf.henshin.editor/src/org/eclipse/emf/henshin/presentation/HenshinEditor.java
+++ b/plugins/org.eclipse.emf.henshin.editor/src/org/eclipse/emf/henshin/presentation/HenshinEditor.java
@@ -1422,16 +1422,15 @@ public class HenshinEditor extends MultiPageEditorPart implements IEditingDomain
 	 * @generated
 	 */
 	@Override
-	@SuppressWarnings("rawtypes")
-	public Object getAdapter(Class key) {
-		if (key.equals(IContentOutlinePage.class)) {
-			return showOutlineView() ? getContentOutlinePage() : null;
+	public <T> T getAdapter(Class<T> key) {
+		if (key == IContentOutlinePage.class) {
+			return showOutlineView() ? key.cast(getContentOutlinePage()) : null;
 		}
-		else if (key.equals(IPropertySheetPage.class)) {
-			return getPropertySheetPage();
+		else if (key == IPropertySheetPage.class) {
+			return key.cast(getPropertySheetPage());
 		}
-		else if (key.equals(IGotoMarker.class)) {
-			return this;
+		else if (key == IGotoMarker.class) {
+			return key.cast(this);
 		}
 		else {
 			return super.getAdapter(key);

--- a/plugins/org.eclipse.emf.henshin.model/src/org/eclipse/emf/henshin/model/util/ScriptEngineWrapper.java
+++ b/plugins/org.eclipse.emf.henshin.model/src/org/eclipse/emf/henshin/model/util/ScriptEngineWrapper.java
@@ -87,7 +87,6 @@ public class ScriptEngineWrapper {
 	 * @return The result.
 	 * @throws ScriptException On script execution errors.
 	 */
-	@SuppressWarnings("unchecked")
 	public Object eval(String script, List<String> localImports) throws ScriptException {
 		if (!globalImports.isEmpty() || !localImports.isEmpty()) {
   			script =  toStringWithImports(script,globalImports, localImports);
@@ -113,13 +112,14 @@ public class ScriptEngineWrapper {
 	/**
 	 * Converts a list of imports like List("foo.Foo", "foo.bar.*") into one string "foo.Foo, foo.bar"
 	 */
+	@SafeVarargs
 	private static String toStringWithImports(String script, List<String>... imports) {
 		StringBuffer out = new StringBuffer();
 		String delim = "";
 		out.append("with (new JavaImporter(");
 		
-		for (int i = 0; i < imports.length; i++) {
-			for (String entry : imports[i]) {
+		for (List<String> importsList : imports) {
+			for (String entry : importsList) {
 				if (isDirectory(entry) || isWildcard(entry)) {
 					out.append(delim).append(stripWildcard(entry));
 					delim = ", ";
@@ -129,8 +129,8 @@ public class ScriptEngineWrapper {
 
 		out.append(")) { ");
 
-		for (int i = 0; i < imports.length; i++) {
-			for (String entry : imports[i]) {
+		for (List<String> importsList : imports) {
+			for (String entry : importsList) {
 				Matcher m = CLASS_FQN_PATTERN.matcher(entry);
 				if (m.matches()) {
 					String filename = m.group(2);

--- a/plugins/org.eclipse.emf.henshin.multicda.cpa.ui/src/org/eclipse/emf/henshin/multicda/cpa/ui/action/ExecuteCpaHandler.java
+++ b/plugins/org.eclipse.emf.henshin.multicda.cpa.ui/src/org/eclipse/emf/henshin/multicda/cpa/ui/action/ExecuteCpaHandler.java
@@ -36,8 +36,8 @@ public class ExecuteCpaHandler extends AbstractHandler {
 	public Object execute(ExecutionEvent event) throws ExecutionException {
 		ISelection sel = HandlerUtil.getActiveMenuSelection(event);
 		if(sel instanceof IStructuredSelection){
-		    IStructuredSelection selection = (IStructuredSelection) sel;
-		    List<IStructuredSelection> selectedFiles = selection.toList();
+			@SuppressWarnings("unchecked")
+			List<IStructuredSelection> selectedFiles = ((IStructuredSelection) sel).toList();
 
 		    Shell shell = HandlerUtil.getActiveShell(event);
 			WizardDialog wizardDialog = new WizardDialog(shell.getShell(), new CpaWizard(selectedFiles));

--- a/plugins/org.eclipse.emf.henshin.multicda.cpa.ui/src/org/eclipse/emf/henshin/multicda/cpa/ui/action/OpenCpHandler.java
+++ b/plugins/org.eclipse.emf.henshin.multicda.cpa.ui/src/org/eclipse/emf/henshin/multicda/cpa/ui/action/OpenCpHandler.java
@@ -45,8 +45,8 @@ public class OpenCpHandler extends AbstractHandler {
 		IWorkbenchWindow window = HandlerUtil.getActiveWorkbenchWindowChecked(event);
 		ISelectionService service = window.getSelectionService();
 		ISelection iSelection = service.getSelection();
-		IStructuredSelection iStructuredSelection = (IStructuredSelection) iSelection;
-		List<IResource> selection = iStructuredSelection.toList();
+		@SuppressWarnings("unchecked")
+		List<IResource> selection = ((IStructuredSelection) iSelection).toList();
 
 		createEditorInputsAndModelURIs(selection);
 		IWorkspace iWorkspace = ResourcesPlugin.getWorkspace();

--- a/plugins/org.eclipse.emf.henshin.multicda.cpa.ui/src/org/eclipse/emf/henshin/multicda/cpa/ui/results/MultiEditorSelectionProvider.java
+++ b/plugins/org.eclipse.emf.henshin.multicda.cpa.ui/src/org/eclipse/emf/henshin/multicda/cpa/ui/results/MultiEditorSelectionProvider.java
@@ -37,12 +37,12 @@ public class MultiEditorSelectionProvider implements IPostSelectionProvider {
 	/**
 	 * Registered selection changed listeners (element type: <code>ISelectionChangedListener</code>).
 	 */
-	private ListenerList listeners = new ListenerList();
+	private ListenerList<ISelectionChangedListener> listeners = new ListenerList<>();
 
 	/**
 	 * Registered post selection changed listeners.
 	 */
-	private ListenerList postListeners = new ListenerList();
+	private ListenerList<ISelectionChangedListener> postListeners = new ListenerList<>();
 
 	/**
 	 * The multi-page editor.

--- a/plugins/org.eclipse.emf.henshin.multicda.cpa/src/org/eclipse/emf/henshin/multicda/cpa/CPAUtility.java
+++ b/plugins/org.eclipse.emf.henshin.multicda.cpa/src/org/eclipse/emf/henshin/multicda/cpa/CPAUtility.java
@@ -229,6 +229,7 @@ public class CPAUtility {
 			eo2.setName(name + ":" + eo2.getName());
 	}
 
+	@SuppressWarnings("unchecked")
 	public static Diagram createDiagram(EObject object) {
 		Diagram diagram = NotationFactory.eINSTANCE.createDiagram();
 		diagram.setMeasurementUnit(MeasurementUnit.PIXEL_LITERAL);

--- a/plugins/variability/org.eclipse.emf.henshin.variability.configuration.ui/src/org/eclipse/emf/henshin/variability/ui/views/VariabilityView.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.configuration.ui/src/org/eclipse/emf/henshin/variability/ui/views/VariabilityView.java
@@ -429,6 +429,7 @@ public class VariabilityView extends ViewPart
 		IObservableValue<?> target = WidgetProperties.text(SWT.Modify).observe(variabilityModelText);
 		variabilityModelTextBindingContext = new DataBindingContext();
 		writableValue = new WritableValue<Rule>();
+		@SuppressWarnings("unchecked")
 		IObservableValue<String> model = EMFProperties.value(HenshinPackage.Literals.MODEL_ELEMENT__ANNOTATIONS)
 				.observeDetail(writableValue);
 //		UpdateValueStrategy strategy = new UpdateValueStrategy();

--- a/plugins/variability/org.eclipse.emf.henshin.variability.mergein/src/org/eclipse/emf/henshin/variability/mergein/clone/IsomorphyChecker.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.mergein/src/org/eclipse/emf/henshin/variability/mergein/clone/IsomorphyChecker.java
@@ -51,7 +51,7 @@ public class IsomorphyChecker {
 	private static void treatEdges(Map<HenshinEdge, Map<HenshinGraph, HenshinEdge>> edgeMappings,
 			Map<HenshinGraph, HenshinGraph> rules2clones) {
 
-		Set<Map> considered = new HashSet<Map>();
+		Set<Map<HenshinGraph, HenshinEdge>> considered = new HashSet<>();
 		for (HenshinEdge e : edgeMappings.keySet()) {
 			Map<HenshinGraph, HenshinEdge> map = edgeMappings.get(e);
 			if (!considered.contains(map)) {

--- a/plugins/variability/org.eclipse.emf.henshin.variability.mergein/src/org/eclipse/emf/henshin/variability/mergein/clustering/BasicMergeSuggestionBuilder.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.mergein/src/org/eclipse/emf/henshin/variability/mergein/clustering/BasicMergeSuggestionBuilder.java
@@ -302,19 +302,19 @@ public class BasicMergeSuggestionBuilder {
 		}
 	}
 
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	protected GraphElement findClone(GraphElement ge, Graph graph, CloneGroup cloneGroup) {
-		Map outerMap = null;
+		Map<GraphElement, Map<Rule, ? extends GraphElement>> outerMap = null;
 		if (ge instanceof Node)
-			outerMap = cloneGroup.getNodeMappings();
+			outerMap = (Map) cloneGroup.getNodeMappings();
 		else if (ge instanceof Edge)
-			outerMap = cloneGroup.getEdgeMappings();
+			outerMap = (Map) cloneGroup.getEdgeMappings();
 		else if (ge instanceof Attribute)
-			outerMap = cloneGroup.getAttributeMappings();
+			outerMap = (Map) cloneGroup.getAttributeMappings();
 		Rule rule = getRule(graph);
 		GraphElement actionElement = getActionElement(ge);
 		if (outerMap != null && rule != null && actionElement != null) {
-			Map innerMap = (Map) outerMap.get(actionElement);
-			GraphElement actionElement2 = (GraphElement) innerMap.get(rule);
+			GraphElement actionElement2 = outerMap.get(actionElement).get(rule);
 			if (actionElement2 != null) {
 				for (GraphElement ge2 : getGraphElements(graph)) {
 					if (getActionElement(ge2) == actionElement2)

--- a/plugins/variability/org.eclipse.emf.henshin.variability.mergein/src/org/eclipse/emf/henshin/variability/mergein/mining/core/ResultFragmentSorter.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.mergein/src/org/eclipse/emf/henshin/variability/mergein/mining/core/ResultFragmentSorter.java
@@ -11,23 +11,11 @@ import de.parsemis.miner.general.Fragment;
 
 public class ResultFragmentSorter {
 
+	private static final Comparator<Fragment<INodeLabel, IEdgeLabel>> BY_FREQUENCY_THEN_MAXIMALNONOVERLAPPINGSUBSET_SIZE = Comparator
+			.<Fragment<INodeLabel, IEdgeLabel>>comparingInt(f -> Integer.parseInt(f.frequency().toString()))
+			.thenComparingInt(f -> f.getMaximalNonOverlappingSubSet().size());
+
 	public static void sort(List<Fragment<INodeLabel, IEdgeLabel>> fragmentList) {
-
-		Collections.sort(fragmentList, new Comparator<Fragment>() {
-
-			@Override
-			public int compare(Fragment frag1, Fragment frag2) {
-				int freq1 = Integer.parseInt(frag1.frequency().toString());
-				int freq2 = Integer.parseInt(frag2.frequency().toString());
-				if (freq1 == freq2) {
-					int frag1size = frag1.getMaximalNonOverlappingSubSet().size();
-					int frag2size = frag1.getMaximalNonOverlappingSubSet().size();
-					if (frag1size == frag2size)
-						return 0;
-					return (frag1size > frag2size) ? 1 : -1;
-				}
-				return freq1 > freq2 ? 1 : -1;
-			}
-		});
+		Collections.sort(fragmentList, BY_FREQUENCY_THEN_MAXIMALNONOVERLAPPINGSUBSET_SIZE);
 	}
 }

--- a/plugins/variability/org.eclipse.emf.henshin.variability.mergein/src/org/eclipse/emf/henshin/variability/mergein/mining/core/TransformationSystemMiner.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability.mergein/src/org/eclipse/emf/henshin/variability/mergein/mining/core/TransformationSystemMiner.java
@@ -51,7 +51,7 @@ public class TransformationSystemMiner {
 
 		if (manager.getMinedFragments() != null && manager.getMinedFragments().size() != 0) {
 			ParsemisParserSerializer ser = new ParsemisParserSerializer();
-			for (Fragment fragment : manager.getMinedFragments()) {
+			for (Fragment<INodeLabel, IEdgeLabel> fragment : manager.getMinedFragments()) {
 						ser.serialize(fragment.toGraph());
 			}
 		} else {

--- a/plugins/variability/org.eclipse.emf.henshin.variability/src/org/eclipse/emf/henshin/variability/matcher/RulePreparator.java
+++ b/plugins/variability/org.eclipse.emf.henshin.variability/src/org/eclipse/emf/henshin/variability/matcher/RulePreparator.java
@@ -4,6 +4,7 @@ import java.util.BitSet;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -94,12 +95,13 @@ public class RulePreparator {
 		return bs;
 	}
 
-	private <T extends GraphElement> void addElementToRemoveList(boolean geIsVariabilityAware, GraphElement ge,
-			Collection<T> list) {
-		if (geIsVariabilityAware) {
-			list.add((T) ((VariabilityGraphElement) ge).getGraphElement());
+	private static <T extends GraphElement> void addElementToRemoveList(T ge, Collection<T> list) {
+		if (ge instanceof VariabilityGraphElement) {
+			@SuppressWarnings("unchecked")
+			T e = (T) ((VariabilityGraphElement) ge).getGraphElement();
+			list.add(e);
 		} else {
-			list.add((T) ge);
+			list.add(ge);
 		}
 	}
 
@@ -111,20 +113,17 @@ public class RulePreparator {
 				continue;
 
 			for (GraphElement ge : elements) {
-				boolean geIsVariabilityAware = ge instanceof VariabilityGraphElement;
-
 				if (ge instanceof Node) {
-					addElementToRemoveList(geIsVariabilityAware, ge, removeNodes);
+					addElementToRemoveList((Node) ge, removeNodes);
 					Set<Mapping> mappings = ruleInfo.getNode2Mapping().get((Node) ge);
 					if (mappings != null) {
 						removeMappings.addAll(mappings);
 					}
-					((Node) ge).getAllEdges()
-							.forEach(edge -> addElementToRemoveList(geIsVariabilityAware, edge, removeEdges));
+					((Node) ge).getAllEdges().forEach(edge -> addElementToRemoveList(edge, removeEdges));
 				} else if (ge instanceof Edge) {
-					addElementToRemoveList(geIsVariabilityAware, ge, removeEdges);
+					addElementToRemoveList((Edge) ge, removeEdges);
 				} else if (ge instanceof Attribute) {
-					addElementToRemoveList(geIsVariabilityAware, ge, removeAttributes);
+					addElementToRemoveList((Attribute) ge, removeAttributes);
 				}
 
 			}
@@ -169,7 +168,9 @@ public class RulePreparator {
 			EStructuralFeature feature = m.eContainingFeature();
 			removeMappingContainingRef.put(m, feature);
 			removeElementContainers.put(m, m.eContainer());
-			((EList<EObject>) m.eContainer().eGet(feature)).remove(m);
+			@SuppressWarnings("unchecked")
+			List<EObject> list = (List<EObject>) m.eContainer().eGet(feature);
+			list.remove(m);
 		}
 		for (Attribute a : removeAttributes) {
 			removeElementContainers.put(a, a.getNode());


### PR DESCRIPTION
Suppress warnings that cannot be resolved because referenced libraries use raw-types too.
Rewrite some parts of the code a bit more to avoid type-safety problems from the beginning.