### PR TITLE
Simplify iteration over matches using MatchFinder

### DIFF
--- a/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/impl/DebugEngineImpl.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/impl/DebugEngineImpl.java
@@ -1,5 +1,6 @@
 package org.eclipse.emf.henshin.interpreter.impl;
 
+import java.util.HashSet;
 import java.util.function.Consumer;
 
 import org.eclipse.emf.henshin.interpreter.EGraph;
@@ -19,7 +20,7 @@ public class DebugEngineImpl extends EngineImpl {
 	public DebugApplicationCondition getDebugApplicationCondition(Rule rule, EGraph graph, Match partialMatch,
 			Consumer<Solution> matchObserver) {
 
-		matchFinder = (MatchFinder) new MatchGenerator(rule, graph, partialMatch).iterator();
+		matchFinder = new MatchFinder(rule, graph, partialMatch, new HashSet<>());
 		ApplicationCondition ac = matchFinder.getSolutionFinder();
 
 		// create a DebugApplicationCondition using the standard
@@ -33,7 +34,7 @@ public class DebugEngineImpl extends EngineImpl {
 	public TestDebugApplicationCondition getTestDebugApplicationCondition(Rule rule, EGraph graph, Match partialMatch,
 			Consumer<Solution> matchObserver) {
 
-		matchFinder = (MatchFinder) new MatchGenerator(rule, graph, partialMatch).iterator();
+		matchFinder = new MatchFinder(rule, graph, partialMatch, new HashSet<>());
 		ApplicationCondition ac = matchFinder.getSolutionFinder();
 
 		// create a DebugApplicationCondition using the standard

--- a/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/impl/EngineImpl.java
+++ b/plugins/org.eclipse.emf.henshin.interpreter/src/org/eclipse/emf/henshin/interpreter/impl/EngineImpl.java
@@ -239,56 +239,9 @@ public class EngineImpl implements Engine {
 		if (partialMatch == null) {
 			partialMatch = new MatchImpl(rule);
 		}
-		return new MatchGenerator(rule, graph, partialMatch);
+		Match match = partialMatch;
+		return () -> new MatchFinder(rule, graph, match, new HashSet<>());
 	}
-
-	/**
-	 * Match generator class. Delegates to {@link MatchFinder}.
-	 */
-	final class MatchGenerator implements Iterable<Match> {
-
-		/**
-		 * Rule to be matched.
-		 */
-		private final Rule rule;
-
-		/**
-		 * Object graph.
-		 */
-		private final EGraph graph;
-
-		/**
-		 * A partial match.
-		 */
-		private final Match partialMatch;
-
-		/**
-		 * Default constructor.
-		 * 
-		 * @param rule
-		 *            Rule to be matched.
-		 * @param graph
-		 *            Object graph.
-		 * @param partialMatch
-		 *            Partial match.
-		 */
-		public MatchGenerator(Rule rule, EGraph graph, Match partialMatch) {
-			this.rule = rule;
-			this.graph = graph;
-			this.partialMatch = partialMatch;
-		}
-
-		/*
-		 * (non-Javadoc)
-		 * 
-		 * @see java.lang.Iterable#iterator()
-		 */
-		@Override
-		public Iterator<Match> iterator() {
-			return new MatchFinder(rule, graph, partialMatch, new HashSet<EObject>());
-		}
-
-	} // MatchGenerator
 
 	/**
 	 * Match finder class. Uses {@link SolutionFinder} to find matches.


### PR DESCRIPTION
This avoids the need for the dictated `MatchGenerator` class.

This will also simplifies
- https://github.com/eclipse-henshin/henshin/pull/4